### PR TITLE
ログインページ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,12 +1,14 @@
-/*
- * require_tree .
- *= require_self
- */
- @import "bootstrap";
+//外部のcssファイルを読み込む
+@import "bootstrap";
+@import url(flash.css);
+@import url(login.css);
+@import url(events/index.css);
 
- //共通カラー
- $main_color: #FF9900;
- $main_hover_color: #FF9966;
+//共通カラー
+$theme_color: #FF9900;
+$theme_hover_color: #FF9966;
+
+// 以下は共通のスタイルです
 
 //ログインユーザー名
 .login-user-name {
@@ -14,53 +16,11 @@
   text-align: right;
 }
 
-//フラッシュメッセージ
-.flash-message-container {
-  position: absolute;
-  top: 8%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-
-.flash-message {
-  border-radius: 5px;
-  padding: 16px 24px;
-  width: 500px;
-  margin: 200px auto 0;
-}
-
-.flash-message.notice {
-  background-color: #bcdfff;
-  color: #0067C0;
-  border: solid 1px #0067C0;
-}
- 
-.flash-message.alert {
-  background-color: #ffd4d1;
-  color: #930403;
-  border: solid 1px #930403;
-}
-
-//ログインページ
-.login-page-container {
-  display: table;
-  margin: 200px auto;
-}
-
 //入力フォーム
 .title {
   font-size: 36px;
   line-height: 48px;
   text-align: center;
-}
-
-.form-container {
-  display: inline-block;
-}
-
-.field {
-  margin-top: 30px;
-  text-align: left;
 }
 
 .label-tag {
@@ -78,29 +38,25 @@
 }
 
 .actions {
-  margin-top: 10px;
   text-align: center;
 }
-
 
 .submit-button {
   width: 200px;
   height: 40px;
-  margin-top: 30px;
   border: none;
   border-radius: 4px;
-  background-color: $main_color;
+  background-color: $theme_color;
   color: #ffffff;
   font-size: 18px;
   white-space: nowrap;
 }
 
 .submit-button:hover {
-  background-color: $main_hover_color;
+  background-color: $theme_hover_color;
 }
 
 .back-button-container {
-  margin-top: 20px;
   text-align: center;
 }
 
@@ -112,10 +68,4 @@
 
 .back-button:hover {
   text-decoration: underline;
-}
-
-//イベント一覧
-.event-list-container {
-  margin: 200px auto;
-  text-align: center;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,121 @@
-@import "bootstrap";
+/*
+ * require_tree .
+ *= require_self
+ */
+ @import "bootstrap";
+
+ //共通カラー
+ $main_color: #FF9900;
+ $main_hover_color: #FF9966;
+
+//ログインユーザー名
+.login-user-name {
+  margin-right: 20px;
+  text-align: right;
+}
+
+//フラッシュメッセージ
+.flash-message-container {
+  position: absolute;
+  top: 8%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.flash-message {
+  border-radius: 5px;
+  padding: 16px 24px;
+  width: 500px;
+  margin: 200px auto 0;
+}
+
+.flash-message.notice {
+  background-color: #bcdfff;
+  color: #0067C0;
+  border: solid 1px #0067C0;
+}
+ 
+.flash-message.alert {
+  background-color: #ffd4d1;
+  color: #930403;
+  border: solid 1px #930403;
+}
+
+//ログインページ
+.login-page-container {
+  display: table;
+  margin: 200px auto;
+}
+
+//入力フォーム
+.title {
+  font-size: 36px;
+  line-height: 48px;
+  text-align: center;
+}
+
+.form-container {
+  display: inline-block;
+}
+
+.field {
+  margin-top: 30px;
+  text-align: left;
+}
+
+.label-tag {
+  color: #000000;
+  font-size: 12px;
+}
+
+.text-field {
+  width: 400px;
+  height: 40px;
+  font-size: 16px;
+  border: 1.5px solid #ccc;
+  background-color: #ffffff;
+  text-align: left;
+}
+
+.actions {
+  margin-top: 10px;
+  text-align: center;
+}
+
+
+.submit-button {
+  width: 200px;
+  height: 40px;
+  margin-top: 30px;
+  border: none;
+  border-radius: 4px;
+  background-color: $main_color;
+  color: #ffffff;
+  font-size: 18px;
+  white-space: nowrap;
+}
+
+.submit-button:hover {
+  background-color: $main_hover_color;
+}
+
+.back-button-container {
+  margin-top: 20px;
+  text-align: center;
+}
+
+.back-button {
+  color: #ccc;
+  font-size: 0.75rem;
+  text-decoration: none;
+}
+
+.back-button:hover {
+  text-decoration: underline;
+}
+
+//イベント一覧
+.event-list-container {
+  margin: 200px auto;
+  text-align: center;
+}

--- a/app/assets/stylesheets/events/index.css
+++ b/app/assets/stylesheets/events/index.css
@@ -1,0 +1,5 @@
+/* イベント一覧 */
+.event-list-container {
+  margin: 200px auto;
+  text-align: center;
+}

--- a/app/assets/stylesheets/flash.scss
+++ b/app/assets/stylesheets/flash.scss
@@ -1,0 +1,28 @@
+@import 'bootstrap';
+
+/* フラッシュメッセージ */
+.flash-message-container {
+  position: absolute;
+  top: 8%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.flash-message {
+  border-radius: 5px;
+  padding: 16px 24px;
+  width: 500px;
+  margin: 200px auto 0;
+}
+
+.flash-message.notice {
+  background-color: $cyan-300;
+  color: #ffffff;
+  border: solid 1px $cyan-300;
+}
+ 
+.flash-message.alert {
+  background-color:  $red-500;
+  color: #ffffff;
+  border: solid 1px $red-500;
+}

--- a/app/assets/stylesheets/login.css
+++ b/app/assets/stylesheets/login.css
@@ -1,0 +1,6 @@
+/* ログインページ */
+.login-page-container {
+  display: table;
+  margin: 200px auto;
+}
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  before_action :require_login
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,7 @@
 class EventsController < ApplicationController
+  skip_before_action :require_login, only: [:index]
+
   def index
+    @message = "イベントの一覧情報を表示します"
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,24 @@
+class SessionsController < ApplicationController
+  skip_before_action :require_login, only: [:new, :create]
+
+  def create
+    @user = login(params[:email], params[:password])
+
+    if @user
+      redirect_back_or_to(root_path)
+    else
+      render action: 'new'
+    end
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def destroy
+    remember_me!
+    forget_me!
+    logout
+    redirect_to(login_path)
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,12 +2,12 @@ class SessionsController < ApplicationController
   skip_before_action :require_login, only: [:new, :create]
 
   def create
-    @user = login(params[:email], params[:password], params[:remember_me])
+    @user = login(params[:email], params[:password])
 
     if @user
       redirect_back_or_to(root_path, notice: 'ログインに成功しました')
     else
-      flash.now[:alert] = 'ログインに失敗しました'
+      flash.now[:alert] = 'メールアドレスかパスワードが正しくありません'
       render action: 'new'
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,11 +2,12 @@ class SessionsController < ApplicationController
   skip_before_action :require_login, only: [:new, :create]
 
   def create
-    @user = login(params[:email], params[:password])
+    @user = login(params[:email], params[:password], params[:remember_me])
 
     if @user
-      redirect_back_or_to(root_path)
+      redirect_back_or_to(root_path, notice: 'ログインに成功しました')
     else
+      flash.now[:alert] = 'ログインに失敗しました'
       render action: 'new'
     end
   end
@@ -19,6 +20,6 @@ class SessionsController < ApplicationController
     remember_me!
     forget_me!
     logout
-    redirect_to(login_path)
+    redirect_to(login_path, notice: 'ログアウトしました')
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,2 @@
+module SessionsHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,5 +3,5 @@ import "@hotwired/turbo-rails"
 import "controllers"
 
 $(function() {
-  $('.flash-message').fadeOut(4000);
+  $('.flash-message').fadeOut(5000);
 });

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,7 @@
-// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "./popper"
 import "bootstrap"
 import "@hotwired/turbo-rails"
 import "controllers"
+
+$(function() {
+  $('.flash-message').fadeOut(4000);
+});

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ApplicationRecord
+  authenticates_with_sorcery!
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,50 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+
+  #名前のバリデーション
+  validates :name, presence: true, length: { maximum: 60 }
+
+  #メールアドレスのバリデーション
+  before_save { self.email = email.downcase }
+  VALID_EMAIL_REGEX = /\A[\w\-\._]+@[\w\-\._]+\.[A-Za-z]+\z/
+  validates :email, uniqueness: true, presence: true, length: { maximum: 255 },
+  format: { with: VALID_EMAIL_REGEX, message: "メールアドレスが正しい形式ではありません" }
+
+  #パスワードのバリデーション
+  VALID_PASSWORD_REGEX = /\A(?=.*[a-z])(?=.*?\d)[\w]+\z/
+  VALID_PASSWORD_MESSAGE_HANKAKU = "パスワードは半角英数字で入力してください"
+  VALID_PASSWORD_MESSAGE_MINLENGTH = "パスワードは8文字以上で入力してください"
+  VALID_PASSWORD_MESSAGE_MAXLENGTH = "パスワードは16文字以内で入力してください"
+  validates :password, presence: true, if: -> { new_record? || changes[:crypted_password] }
+  validate :validate_password
+
+  #電話番号のバリデーション
+  VALID_PHONE_NUMBER_REGEX = /\A\d{10,11}\z/
+  VALID_PHONE_NUMBER_MESSAGE_HAIFUN = "電話番号はハイフン無しで入力してください"
+  VALID_PHONE_NUMBER_MESSAGE_HANKAKU = "電話番号は半角数字で入力してください"
+  VALID_PHONE_NUMBER_MESSAGE_LENGTH = "電話番号は10桁か11桁で入力してください"
+  validate :validate_phone_number
+  validates :phone_number, presence: true
+
+  #自己紹介文のバリデーション
+  validates :self_introduction, length: { maximum: 256 }
+
+  private
+
+  def validate_password
+    if password.present?
+      errors.add(:password, VALID_PASSWORD_MESSAGE_HANKAKU) unless password =~ VALID_PASSWORD_REGEX
+      errors.add(:password, VALID_PASSWORD_MESSAGE_MINLENGTH) unless password.length >= 8
+    errors.add(:password, VALID_PASSWORD_MESSAGE_MAXLENGTH) unless password.length <= 16
+    end
+  end
+
+  def validate_phone_number
+    if phone_number.present?
+      errors.add(:phone_number, VALID_PHONE_NUMBER_MESSAGE_HAIFUN) if phone_number.include?('-');
+      errors.add(:phone_number, VALID_PHONE_NUMBER_MESSAGE_HANKAKU) unless phone_number =~ /\A\d+\z/
+      errors.add(:phone_number, VALID_PHONE_NUMBER_MESSAGE_LENGTH) unless phone_number =~ VALID_PHONE_NUMBER_REGEX
+    end
+  end
+
 end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,2 +1,7 @@
+<div class="flash-message-container">
+  <%= render 'shared/flash_message' %>
+</div>
+
+<div class="event-list-container">
 <h1>イベント一覧ページ</h1>
 <p><%= @message %></p>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,2 +1,2 @@
-<h1>Events#index</h1>
-<p class="alert alert-info" role="alert">Find me in app/views/events/index.html.erb</p>
+<h1>イベント一覧ページ</h1>
+<p><%= @message %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,13 +8,15 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   </head>
 
   <body>
     <% if logged_in? %>
-      <p><%= current_user.name %>さん</p>
+      <p class="login-user-name"><%= current_user.name %>さん</p>
     <% else %>
-      <p>ゲストさん</p>
+      <p class="login-user-name">ゲストさん</p>
     <% end %>
     <%= yield %>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,11 @@
   </head>
 
   <body>
+    <% if logged_in? %>
+      <p><%= current_user.name %>さん</p>
+    <% else %>
+      <p>ゲストさん</p>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,17 +1,28 @@
-<h1>ログイン</h1>
+<div class="flash-message-container">
+  <%= render 'shared/flash_message' %>
+</div>
 
-<%= form_with url: login_path, method: :post, data: { turbo: false } do |f| %>
-  <div class="field">
-    <%= f.label "メールアドレス" %><br />
-    <%= f.text_field :email %>
-  </div>
-  <div class="field">
-    <%= f.label "パスワード" %><br />
-    <%= f.password_field :password %>
-  </div>
-  <div class="actions">
-    <%= f.submit "ログイン", data: { turbo: false } %>
-  </div>
-<% end %>
+<div class="login-page-container">
+  <h1 class="title">ログイン</h1>
+  <div class="form-container" data-turbo="false">
 
-<%= link_to 'イベント一覧に戻る', root_path, data: { turbo: false } %>
+    <%= form_with url: login_path, method: :post, data: { turbo: false } do |f| %>
+      <div class="field">
+        <%= f.label "メールアドレス", class:"label-tag" %><br />
+        <%= f.text_field :email, class:"text-field" %>
+      </div>
+      <div class="field">
+        <%= f.label "パスワード", class:"label-tag" %><br />
+        <%= f.password_field :password, class:"text-field" %>
+      </div>
+      <div class="actions">
+        <%= f.submit "ログイン", class: "submit-button", data: { turbo: false } %>
+      </div>
+      <div class="back-button-container">
+        <%= link_to 'イベント一覧に戻る', root_path, class:"back-button", data: { turbo: false } %>
+      </div>
+    <% end %>
+
+  </div>
+</div>
+

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -4,25 +4,21 @@
 
 <div class="login-page-container">
   <h1 class="title">ログイン</h1>
-  <div class="form-container" data-turbo="false">
-
-    <%= form_with url: login_path, method: :post, data: { turbo: false } do |f| %>
-      <div class="field">
-        <%= f.label "メールアドレス", class:"label-tag" %><br />
-        <%= f.text_field :email, class:"text-field" %>
-      </div>
-      <div class="field">
-        <%= f.label "パスワード", class:"label-tag" %><br />
-        <%= f.password_field :password, class:"text-field" %>
-      </div>
-      <div class="actions">
-        <%= f.submit "ログイン", class: "submit-button", data: { turbo: false } %>
-      </div>
-      <div class="back-button-container">
-        <%= link_to 'イベント一覧に戻る', root_path, class:"back-button", data: { turbo: false } %>
-      </div>
-    <% end %>
-
-  </div>
+  <%= form_with url: login_path, method: :post do |f| %>
+    <div class="mt-4 mb-4">
+      <%= f.label "メールアドレス", class:"label-tag fw-bold" %><br />
+      <%= f.text_field :email, class:"text-field p-2" %>
+    </div>
+    <div class="mt-4 mb-2">
+      <%= f.label "パスワード", class:"label-tag fw-bold" %><br />
+      <%= f.password_field :password, class:"text-field p-2", autocomplete:"off" %>
+    </div>
+    <div class="actions mt-5">
+      <%= f.submit "ログイン", class: "submit-button", data: { turbo: false } %>
+    </div>
+    <div class="back-button-container mt-3">
+      <%= link_to 'イベント一覧に戻る', root_path, class:"back-button", data: { turbo: false } %>
+    </div>
+  <% end %>
 </div>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,17 @@
+<h1>ログイン</h1>
+
+<%= form_with url: login_path, method: :post, data: { turbo: false } do |f| %>
+  <div class="field">
+    <%= f.label "メールアドレス" %><br />
+    <%= f.text_field :email %>
+  </div>
+  <div class="field">
+    <%= f.label "パスワード" %><br />
+    <%= f.password_field :password %>
+  </div>
+  <div class="actions">
+    <%= f.submit "ログイン", data: { turbo: false } %>
+  </div>
+<% end %>
+
+<%= link_to 'イベント一覧に戻る', root_path, data: { turbo: false } %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,5 @@
+<div>
+  <% flash.each do |message_type, message| %>
+    <div class="flash-message <%= message_type %>"><%= message %></div>
+  <% end %>
+</div>

--- a/bin/db_setup.sh
+++ b/bin/db_setup.sh
@@ -1,0 +1,8 @@
+#コマンドを一括実行
+rails db:drop
+
+rails db:create
+
+rails db:migrate
+
+rails db:seed

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,11 @@ module EventManagementApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    #sorceryインストール時のみ追加
+    # class ActiveRecord::Base
+    #   singleton_class.attr_accessor :timestamped_migrations
+    #   self.timestamped_migrations = true
+    # end
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -30,6 +30,9 @@ development:
 test:
   <<: *default
   database: event-management-app_test
+  host: db
+  username: root
+  password: password
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,4 +10,4 @@ Rails.application.config.assets.version = "1.0"
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-Rails.application.config.assets.precompile += %w(bootstrap.min.js popper.js)
+Rails.application.config.assets.precompile += %w(bootstrap.min.js popper.js application.css)

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -1,0 +1,567 @@
+# The first thing you need to configure is which modules you need in your app.
+# The default is nothing which will include only core features (password encryption, login/logout).
+#
+# Available submodules are: :user_activation, :http_basic_auth, :remember_me,
+# :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
+# :magic_login, :external
+Rails.application.config.sorcery.submodules = []
+
+# Here you can configure each submodule's features.
+Rails.application.config.sorcery.configure do |config|
+  # -- core --
+  # What controller action to call for non-authenticated users. You can also
+  # override the 'not_authenticated' method of course.
+  # Default: `:not_authenticated`
+  #
+  # config.not_authenticated_action =
+
+  # When a non logged-in user tries to enter a page that requires login, save
+  # the URL he wants to reach, and send him there after login, using 'redirect_back_or_to'.
+  # Default: `true`
+  #
+  # config.save_return_to_url =
+
+  # Set domain option for cookies; Useful for remember_me submodule.
+  # Default: `nil`
+  #
+  # config.cookie_domain =
+
+  # Allow the remember_me cookie to be set through AJAX
+  # Default: `true`
+  #
+  # config.remember_me_httponly =
+
+  # Set token randomness. (e.g. user activation tokens)
+  # The length of the result string is about 4/3 of `token_randomness`.
+  # Default: `15`
+  #
+  # config.token_randomness =
+
+  # -- session timeout --
+  # How long in seconds to keep the session alive.
+  # Default: `3600`
+  #
+  # config.session_timeout =
+
+  # Use the last action as the beginning of session timeout.
+  # Default: `false`
+  #
+  # config.session_timeout_from_last_action =
+
+  # Invalidate active sessions. Requires an `invalidate_sessions_before` timestamp column
+  # Default: `false`
+  #
+  # config.session_timeout_invalidate_active_sessions_enabled =
+
+  # -- http_basic_auth --
+  # What realm to display for which controller name. For example {"My App" => "Application"}
+  # Default: `{"application" => "Application"}`
+  #
+  # config.controller_to_realm_map =
+
+  # -- activity logging --
+  # Will register the time of last user login, every login.
+  # Default: `true`
+  #
+  # config.register_login_time =
+
+  # Will register the time of last user logout, every logout.
+  # Default: `true`
+  #
+  # config.register_logout_time =
+
+  # Will register the time of last user action, every action.
+  # Default: `true`
+  #
+  # config.register_last_activity_time =
+
+  # -- external --
+  # What providers are supported by this app
+  # i.e. [:twitter, :facebook, :github, :linkedin, :xing, :google, :liveid, :salesforce, :slack, :line].
+  # Default: `[]`
+  #
+  # config.external_providers =
+
+  # You can change it by your local ca_file. i.e. '/etc/pki/tls/certs/ca-bundle.crt'
+  # Path to ca_file. By default use a internal ca-bundle.crt.
+  # Default: `'path/to/ca_file'`
+  #
+  # config.ca_file =
+
+  # Linkedin requires r_emailaddress scope to fetch user's email address.
+  # You can skip including the email field if you use an intermediary signup form. (using build_from method).
+  # The r_emailaddress scope is only necessary if you are using the create_from method directly.
+  #
+  # config.linkedin.key = ""
+  # config.linkedin.secret = ""
+  # config.linkedin.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=linkedin"
+  # config.linkedin.user_info_mapping = {
+  #   first_name: 'localizedFirstName',
+  #   last_name:  'localizedLastName',
+  #   email:      'emailAddress'
+  # }
+  # config.linkedin.scope = "r_liteprofile r_emailaddress"
+  #
+  #
+  # For information about XING API:
+  # - user info fields go to https://dev.xing.com/docs/get/users/me
+  #
+  # config.xing.key = ""
+  # config.xing.secret = ""
+  # config.xing.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=xing"
+  # config.xing.user_info_mapping = {first_name: "first_name", last_name: "last_name"}
+  #
+  #
+  # Twitter will not accept any requests nor redirect uri containing localhost,
+  # Make sure you use 0.0.0.0:3000 to access your app in development
+  #
+  # config.twitter.key = ""
+  # config.twitter.secret = ""
+  # config.twitter.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=twitter"
+  # config.twitter.user_info_mapping = {:email => "screen_name"}
+  #
+  # config.facebook.key = ""
+  # config.facebook.secret = ""
+  # config.facebook.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=facebook"
+  # config.facebook.user_info_path = "me?fields=email"
+  # config.facebook.user_info_mapping = {:email => "email"}
+  # config.facebook.access_permissions = ["email"]
+  # config.facebook.display = "page"
+  # config.facebook.api_version = "v2.3"
+  # config.facebook.parse = :json
+  #
+  # config.instagram.key = ""
+  # config.instagram.secret = ""
+  # config.instagram.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=instagram"
+  # config.instagram.user_info_mapping = {:email => "username"}
+  # config.instagram.access_permissions = ["basic", "public_content", "follower_list", "comments", "relationships", "likes"]
+  #
+  # config.github.key = ""
+  # config.github.secret = ""
+  # config.github.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=github"
+  # config.github.user_info_mapping = {:email => "name"}
+  # config.github.scope = ""
+  #
+  # config.paypal.key = ""
+  # config.paypal.secret = ""
+  # config.paypal.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=paypal"
+  # config.paypal.user_info_mapping = {:email => "email"}
+  #
+  # config.wechat.key = ""
+  # config.wechat.secret = ""
+  # config.wechat.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=wechat"
+  #
+  # For Auth0, site is required and should match the domain provided by Auth0.
+  #
+  # config.auth0.key = ""
+  # config.auth0.secret = ""
+  # config.auth0.callback_url = "https://0.0.0.0:3000/oauth/callback?provider=auth0"
+  # config.auth0.site = "https://example.auth0.com"
+  #
+  # config.google.key = ""
+  # config.google.secret = ""
+  # config.google.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=google"
+  # config.google.user_info_mapping = {:email => "email", :username => "name"}
+  # config.google.scope = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
+  #
+  # For Microsoft Graph, the key will be your App ID, and the secret will be your app password/public key.
+  # The callback URL "can't contain a query string or invalid special characters"
+  # See: https://docs.microsoft.com/en-us/azure/active-directory/active-directory-v2-limitations#restrictions-on-redirect-uris
+  # More information at https://graph.microsoft.io/en-us/docs
+  #
+  # config.microsoft.key = ""
+  # config.microsoft.secret = ""
+  # config.microsoft.callback_url = "http://0.0.0.0:3000/oauth/callback/microsoft"
+  # config.microsoft.user_info_mapping = {:email => "userPrincipalName", :username => "displayName"}
+  # config.microsoft.scope = "openid email https://graph.microsoft.com/User.Read"
+  #
+  # config.vk.key = ""
+  # config.vk.secret = ""
+  # config.vk.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=vk"
+  # config.vk.user_info_mapping = {:login => "domain", :name => "full_name"}
+  # config.vk.api_version = "5.71"
+  #
+  # config.slack.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=slack"
+  # config.slack.key = ''
+  # config.slack.secret = ''
+  # config.slack.user_info_mapping = {email: 'email'}
+  #
+  # To use liveid in development mode you have to replace mydomain.com with
+  # a valid domain even in development. To use a valid domain in development
+  # simply add your domain in your /etc/hosts file in front of 127.0.0.1
+  #
+  # config.liveid.key = ""
+  # config.liveid.secret = ""
+  # config.liveid.callback_url = "http://mydomain.com:3000/oauth/callback?provider=liveid"
+  # config.liveid.user_info_mapping = {:username => "name"}
+
+  # For information about JIRA API:
+  # https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+Example+-+OAuth+authentication
+  # To obtain the consumer key and the public key you can use the jira-ruby gem https://github.com/sumoheavy/jira-ruby
+  # or run openssl req -x509 -nodes -newkey rsa:1024 -sha1 -keyout rsakey.pem -out rsacert.pem to obtain the public key
+  # Make sure you have configured the application link properly
+
+  # config.jira.key = "1234567"
+  # config.jira.secret = "jiraTest"
+  # config.jira.site = "http://localhost:2990/jira/plugins/servlet/oauth"
+  # config.jira.signature_method =  "RSA-SHA1"
+  # config.jira.private_key_file = "rsakey.pem"
+
+  # For information about Salesforce API:
+  # https://developer.salesforce.com/signup &
+  # https://www.salesforce.com/us/developer/docs/api_rest/
+  # Salesforce callback_url must be https. You can run the following to generate self-signed ssl cert:
+  # openssl req -new -newkey rsa:2048 -sha1 -days 365 -nodes -x509 -keyout server.key -out server.crt
+  # Make sure you have configured the application link properly
+  # config.salesforce.key = '123123'
+  # config.salesforce.secret = 'acb123'
+  # config.salesforce.callback_url = "https://127.0.0.1:9292/oauth/callback?provider=salesforce"
+  # config.salesforce.scope = "full"
+  # config.salesforce.user_info_mapping = {:email => "email"}
+
+  # config.line.key = ""
+  # config.line.secret = ""
+  # config.line.callback_url = "http://mydomain.com:3000/oauth/callback?provider=line"
+  # config.line.scope = "profile"
+  # config.line.bot_prompt = "normal"
+  # config.line.user_info_mapping = {name: 'displayName'}
+
+  
+  # For information about Discord API
+  # https://discordapp.com/developers/docs/topics/oauth2
+  # config.discord.key = "xxxxxx"
+  # config.discord.secret = "xxxxxx"
+  # config.discord.callback_url = "http://localhost:3000/oauth/callback?provider=discord"
+  # config.discord.scope = "email guilds"
+
+  # For information about Battlenet API
+  # https://develop.battle.net/documentation/guides/using-oauth
+  # config.battlenet.site = "https://eu.battle.net/" #See Website for other Regional Domains
+  # config.battlenet.key = "xxxxxx"
+  # config.battlenet.secret = "xxxxxx"
+  # config.battlenet.callback_url = "http://localhost:3000/oauth/callback?provider=battlenet"
+  # config.battlenet.scope = "openid"
+  # --- user config ---
+  config.user_config do |user|
+    # -- core --
+    # Specify username attributes, for example: [:username, :email].
+    # Default: `[:email]`
+    #
+    # user.username_attribute_names =
+
+    # Change *virtual* password attribute, the one which is used until an encrypted one is generated.
+    # Default: `:password`
+    #
+    # user.password_attribute_name =
+
+    # Downcase the username before trying to authenticate, default is false
+    # Default: `false`
+    #
+    # user.downcase_username_before_authenticating =
+
+    # Change default email attribute.
+    # Default: `:email`
+    #
+    # user.email_attribute_name =
+
+    # Change default crypted_password attribute.
+    # Default: `:crypted_password`
+    #
+    # user.crypted_password_attribute_name =
+
+    # What pattern to use to join the password with the salt
+    # Default: `""`
+    #
+    # user.salt_join_token =
+
+    # Change default salt attribute.
+    # Default: `:salt`
+    #
+    # user.salt_attribute_name =
+
+    # How many times to apply encryption to the password.
+    # Default: 1 in test env, `nil` otherwise
+    #
+    user.stretches = 1 if Rails.env.test?
+
+    # Encryption key used to encrypt reversible encryptions such as AES256.
+    # WARNING: If used for users' passwords, changing this key will leave passwords undecryptable!
+    # Default: `nil`
+    #
+    # user.encryption_key =
+
+    # Use an external encryption class.
+    # Default: `nil`
+    #
+    # user.custom_encryption_provider =
+
+    # Encryption algorithm name. See 'encryption_algorithm=' for available options.
+    # Default: `:bcrypt`
+    #
+    # user.encryption_algorithm =
+
+    # Make this configuration inheritable for subclasses. Useful for ActiveRecord's STI.
+    # Default: `false`
+    #
+    # user.subclasses_inherit_config =
+
+    # -- remember_me --
+    # change default remember_me_token attribute.
+    # Default: `:remember_me_token`
+    #
+    # user.remember_me_token_attribute_name =
+
+    # change default remember_me_token_expires_at attribute.
+    # Default: `:remember_me_token_expires_at`
+    #
+    # user.remember_me_token_expires_at_attribute_name =
+
+    # How long in seconds the session length will be
+    # Default: `60 * 60 * 24 * 7`
+    #
+    # user.remember_me_for =
+
+    # When true, sorcery will persist a single remember me token for all
+    # logins/logouts (to support remembering on multiple browsers simultaneously).
+    # Default: false
+    #
+    # user.remember_me_token_persist_globally =
+
+    # -- user_activation --
+    # The attribute name to hold activation state (active/pending).
+    # Default: `:activation_state`
+    #
+    # user.activation_state_attribute_name =
+
+    # The attribute name to hold activation code (sent by email).
+    # Default: `:activation_token`
+    #
+    # user.activation_token_attribute_name =
+
+    # The attribute name to hold activation code expiration date.
+    # Default: `:activation_token_expires_at`
+    #
+    # user.activation_token_expires_at_attribute_name =
+
+    # How many seconds before the activation code expires. nil for never expires.
+    # Default: `nil`
+    #
+    # user.activation_token_expiration_period =
+
+    # REQUIRED:
+    # User activation mailer class.
+    # Default: `nil`
+    #
+    # user.user_activation_mailer =
+
+    # When true, sorcery will not automatically
+    # send the activation details email, and allow you to
+    # manually handle how and when the email is sent.
+    # Default: `false`
+    #
+    # user.activation_mailer_disabled =
+
+    # Method to send email related
+    # options: `:deliver_later`, `:deliver_now`, `:deliver`
+    # Default: :deliver (Rails version < 4.2) or :deliver_now (Rails version 4.2+)
+    #
+    # user.email_delivery_method =
+
+    # Activation needed email method on your mailer class.
+    # Default: `:activation_needed_email`
+    #
+    # user.activation_needed_email_method_name =
+
+    # Activation success email method on your mailer class.
+    # Default: `:activation_success_email`
+    #
+    # user.activation_success_email_method_name =
+
+    # Do you want to prevent users who did not activate by email from logging in?
+    # Default: `true`
+    #
+    # user.prevent_non_active_users_to_login =
+
+    # -- reset_password --
+    # Password reset token attribute name.
+    # Default: `:reset_password_token`
+    #
+    # user.reset_password_token_attribute_name =
+
+    # Password token expiry attribute name.
+    # Default: `:reset_password_token_expires_at`
+    #
+    # user.reset_password_token_expires_at_attribute_name =
+
+    # When was password reset email sent. Used for hammering protection.
+    # Default: `:reset_password_email_sent_at`
+    #
+    # user.reset_password_email_sent_at_attribute_name =
+
+    # REQUIRED:
+    # Password reset mailer class.
+    # Default: `nil`
+    #
+    # user.reset_password_mailer =
+
+    # Reset password email method on your mailer class.
+    # Default: `:reset_password_email`
+    #
+    # user.reset_password_email_method_name =
+
+    # When true, sorcery will not automatically
+    # send the password reset details email, and allow you to
+    # manually handle how and when the email is sent
+    # Default: `false`
+    #
+    # user.reset_password_mailer_disabled =
+
+    # How many seconds before the reset request expires. nil for never expires.
+    # Default: `nil`
+    #
+    # user.reset_password_expiration_period =
+
+    # Hammering protection: how long in seconds to wait before allowing another email to be sent.
+    # Default: `5 * 60`
+    #
+    # user.reset_password_time_between_emails =
+
+    # Access counter to a reset password page attribute name
+    # Default: `:access_count_to_reset_password_page`
+    #
+    # user.reset_password_page_access_count_attribute_name =
+
+    # -- magic_login --
+    # Magic login code attribute name.
+    # Default: `:magic_login_token`
+    #
+    # user.magic_login_token_attribute_name =
+
+    # Magic login expiry attribute name.
+    # Default: `:magic_login_token_expires_at`
+    #
+    # user.magic_login_token_expires_at_attribute_name =
+
+    # When was magic login email sent — used for hammering protection.
+    # Default: `:magic_login_email_sent_at`
+    #
+    # user.magic_login_email_sent_at_attribute_name =
+
+    # REQUIRED:
+    # Magic login mailer class.
+    # Default: `nil`
+    #
+    # user.magic_login_mailer_class =
+
+    # Magic login email method on your mailer class.
+    # Default: `:magic_login_email`
+    #
+    # user.magic_login_email_method_name =
+
+    # When true, sorcery will not automatically
+    # send magic login details email, and allow you to
+    # manually handle how and when the email is sent
+    # Default: `true`
+    #
+    # user.magic_login_mailer_disabled =
+
+    # How many seconds before the request expires. nil for never expires.
+    # Default: `nil`
+    #
+    # user.magic_login_expiration_period =
+
+    # Hammering protection: how long in seconds to wait before allowing another email to be sent.
+    # Default: `5 * 60`
+    #
+    # user.magic_login_time_between_emails =
+
+    # -- brute_force_protection --
+    # Failed logins attribute name.
+    # Default: `:failed_logins_count`
+    #
+    # user.failed_logins_count_attribute_name =
+
+    # This field indicates whether user is banned and when it will be active again.
+    # Default: `:lock_expires_at`
+    #
+    # user.lock_expires_at_attribute_name =
+
+    # How many failed logins are allowed.
+    # Default: `50`
+    #
+    # user.consecutive_login_retries_amount_limit =
+
+    # How long the user should be banned, in seconds. 0 for permanent.
+    # Default: `60 * 60`
+    #
+    # user.login_lock_time_period =
+
+    # Unlock token attribute name
+    # Default: `:unlock_token`
+    #
+    # user.unlock_token_attribute_name =
+
+    # Unlock token mailer method
+    # Default: `:send_unlock_token_email`
+    #
+    # user.unlock_token_email_method_name =
+
+    # When true, sorcery will not automatically
+    # send email with the unlock token
+    # Default: `false`
+    #
+    # user.unlock_token_mailer_disabled = true
+
+    # REQUIRED:
+    # Unlock token mailer class.
+    # Default: `nil`
+    #
+    # user.unlock_token_mailer =
+
+    # -- activity logging --
+    # Last login attribute name.
+    # Default: `:last_login_at`
+    #
+    # user.last_login_at_attribute_name =
+
+    # Last logout attribute name.
+    # Default: `:last_logout_at`
+    #
+    # user.last_logout_at_attribute_name =
+
+    # Last activity attribute name.
+    # Default: `:last_activity_at`
+    #
+    # user.last_activity_at_attribute_name =
+
+    # How long since user's last activity will they be considered logged out?
+    # Default: `10 * 60`
+    #
+    # user.activity_timeout =
+
+    # -- external --
+    # Class which holds the various external provider data for this user.
+    # Default: `nil`
+    #
+    # user.authentications_class =
+
+    # User's identifier in the `authentications` class.
+    # Default: `:user_id`
+    #
+    # user.authentications_user_id_attribute_name =
+
+    # Provider's identifier in the `authentications` class.
+    # Default: `:provider`
+    #
+    # user.provider_attribute_name =
+
+    # User's external unique identifier in the `authentications` class.
+    # Default: `:uid`
+    #
+    # user.provider_uid_attribute_name =
+  end
+
+  # This line must come after the 'user config' block.
+  # Define which model authenticates with sorcery.
+  config.user_class = "User"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,9 @@
 Rails.application.routes.draw do
   root "events#index"
+
+  get 'login' => 'sessions#new', as: :login
+  post 'login' => "sessions#create"
+  delete 'logout' => 'sessions#destroy', as: :logout
+
+  resources :events
 end

--- a/db/migrate/20240412124237_sorcery_core.rb
+++ b/db/migrate/20240412124237_sorcery_core.rb
@@ -2,7 +2,7 @@ class SorceryCore < ActiveRecord::Migration[7.1]
   def change
     create_table :users do |t|
       t.string :email,            null: false, index: { unique: true }
-      t.string :crypted_password, null: false
+      t.string :crypted_password
       t.string :salt
 
       t.timestamps                null: false

--- a/db/migrate/20240412124237_sorcery_core.rb
+++ b/db/migrate/20240412124237_sorcery_core.rb
@@ -1,0 +1,11 @@
+class SorceryCore < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :email,            null: false, index: { unique: true }
+      t.string :crypted_password, null: false
+      t.string :salt
+
+      t.timestamps                null: false
+    end
+  end
+end

--- a/db/migrate/20240412211739_add_column_users.rb
+++ b/db/migrate/20240412211739_add_column_users.rb
@@ -1,0 +1,8 @@
+class AddColumnUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :name, :string, null: false
+    add_column :users, :phone_number, :string, null: false
+    add_column :users, :self_introduction, :string
+    add_column :users, :discard_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,27 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2024_04_12_211739) do
+  create_table "users", charset: "utf8mb4", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "crypted_password", null: false
+    t.string "salt"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "name", null: false
+    t.string "phone_number", null: false
+    t.string "self_introduction"
+    t.datetime "discard_at"
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 ActiveRecord::Schema[7.1].define(version: 2024_04_12_211739) do
   create_table "users", charset: "utf8mb4", force: :cascade do |t|
     t.string "email", null: false
-    t.string "crypted_password", null: false
+    t.string "crypted_password"
     t.string "salt"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,3 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+10.times do |n|
+  User.create!(name: "test#{n+1}", email: "test#{n+1}@example.com", password: "password#{n+1}", phone_number: "031234000#{n+1}", self_introduction: "テストユーザー#{n+1}です")
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,5 +19,7 @@ services:
       - .:/event-management-app
     ports:
       - "3000:3000"
+    environment:
+        RAILS_ENV: development 
     depends_on:
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,5 @@ services:
       - .:/event-management-app
     ports:
       - "3000:3000"
-    environment:
-        RAILS_ENV: development 
     depends_on:
       - db

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## チケットへのリンク
- https://prum.backlog.com/view/PRUM_ACADEMY-2317

## やったこと
- ログイン機能の作成（sorceryを使用）
- bootstrapによるcssスタイリング
- ログインユーザー名の表示（ログイン確認用）
- バリデーション（フラッシュメッセージで表示）
- ログイン成功後のフラッシュメッセージ表示
- jqueryによるフラッシュメッセージの非表示処理（5秒後に消える）
- 一覧ページへ戻るボタン実装

## やらないこと
- ヘッダー・フッターの表示（別タスクで実施）
- ログアウト機能の実装（ヘッダー作成時に実施）
- ユーザー名が長い場合の処理（別タスクで実施）
- イベント一覧ページの実装（別タスクで実施）

## できるようになること（ユーザ目線）
- ログインができる
- ログインページから一覧ページへ戻れる
- ログイン後にユーザー名を確認できる

## できなくなること（ユーザ目線）
- ログアウト（別タスクで実施）

## 動作確認
1. http://localhost:3000/login にアクセス
2. 正しいメールアドレスとパスワードを入力してログインボタンをクリック
3. イベント一覧ページにリダイレクトし、フラッシュメッセージが表示されればOK
4. 不正なメールアドレスかパスワードを入力もしくは未入力時にエラーメッセージが表示されればOK

https://github.com/kyohei-p/event-management-app/assets/107188352/dfdc051b-6a65-4872-9bf3-edec7c1a039e


## レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- イベント一覧ページ未実装のため、仮でタイトルなどを表示しています。
- 認証機能には[sorcery](https://github.com/Sorcery/sorcery)を採用しています。
- ユーザー登録用のバリデーションも本タスクで追加しました。
- bootstrapのcssを使用していますが、細かなカスタマイズを行うときは素のcssを使う方向で考えています。
- デザインに関しては指示がないため、こちらでレイアウトや色を決めて実装しています。
- `bash bin/db_setup.sh`をターミナルで実行するとDBの削除からSeedの再投入まで一括で行えます（`rails db:migrate:reset`がうまくいかなかった時に作成しましたが、代替手段として残しています）

## その他
実績時間： 11h