### PR TITLE
パンくずリスト

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'bootstrap', '~> 5.3.2'
 gem 'mini_racer'
 gem 'kaminari'
 gem 'bootstrap5-kaminari-views'
+gem 'breadcrumbs_on_rails'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,8 @@ GEM
     bootstrap5-kaminari-views (0.0.1)
       kaminari (>= 0.13)
       rails (>= 3.1)
+    breadcrumbs_on_rails (4.1.0)
+      railties (>= 5.0)
     builder (3.2.4)
     capybara (3.40.0)
       addressable
@@ -358,6 +360,7 @@ DEPENDENCIES
   bootsnap
   bootstrap (~> 5.3.2)
   bootstrap5-kaminari-views
+  breadcrumbs_on_rails
   capybara
   debug
   discard

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,13 @@
 /* フラッシュメッセージ */
 .flash-message-container {
   position: absolute;
+  top: 5%;
+  left: 75%;
+  transform: translate(-50%, -50%);
+}
+
+.form-flash-message-container {
+  position: absolute;
   top: 8%;
   left: 50%;
   transform: translate(-50%, -50%);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,8 +14,8 @@
 /* フラッシュメッセージ */
 .flash-message-container {
   position: absolute;
-  top: 5%;
-  left: 75%;
+  top: 8%;
+  left: 50%;
   transform: translate(-50%, -50%);
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,7 @@
 @import url(events/index.css);
 @import url(events/edit.css);
 @import url(events/pagination.css);
+@import url(events/manage_index.css);
 
 /* フラッシュメッセージ */
 .flash-message-container {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,7 +14,7 @@
 /* フラッシュメッセージ */
 .flash-message-container {
   position: absolute;
-  top: 8%;
+  top: 12%;
   left: 50%;
   transform: translate(-50%, -50%);
 }
@@ -36,4 +36,14 @@
   background-color:  $red-500;
   color: #ffffff;
   border: solid 1px $red-500;
+}
+
+/* レスポンシブ対応（iPhoneSE） */
+@media screen and (max-width: 399px){
+  .flash-message-container {
+    position: absolute;
+    top: 12%;
+    left: 60%;
+    transform: translate(-50%, -50%);
+  }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,7 +8,6 @@
 @import url(shared/modal.css);
 @import url(login.css);
 @import url(events/index.css);
-@import url(events/edit.css);
 @import url(events/pagination.css);
 @import url(events/manage_index.css);
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,13 +19,6 @@
   transform: translate(-50%, -50%);
 }
 
-.form-flash-message-container {
-  position: absolute;
-  top: 8%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-
 .flash-message {
   border-radius: 5px;
   padding: 16px 24px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,8 +5,10 @@
 @import url(shared/error.css);
 @import url(shared/header.css);
 @import url(shared/footer.css);
+@import url(shared/modal.css);
 @import url(login.css);
 @import url(events/index.css);
+@import url(events/edit.css);
 @import url(events/pagination.css);
 
 /* フラッシュメッセージ */

--- a/app/assets/stylesheets/events/index.css
+++ b/app/assets/stylesheets/events/index.css
@@ -107,10 +107,6 @@
   margin-top: 100px;
 }
 
-.loggedin-title-container {
-  margin-top: 200px;
-}
-
 .event-list-container {
   display: grid;
   grid-template-columns: auto auto;
@@ -278,18 +274,10 @@
     margin-bottom: 50px;
   }
 
-  .title-container {
-    margin-top: 100px;
-  }
-
   .feature-container {
     display: inline-block;
     margin: 100px auto 50px;
     width: 400px;
-  }
-
-  .loggedin-title-container {
-    margin-top: 200px;
   }
 
   .event-list-container {
@@ -404,14 +392,6 @@
     padding-bottom: 100px;
     color: var(--theme_color);
     background-color: #fff8dc;
-  }
-
-  .title-container {
-    margin-top: 100px;
-  }
-
-  .loggedin-title-container {
-    margin-top: 200px;
   }
 
   .event-list-container {

--- a/app/assets/stylesheets/events/index.css
+++ b/app/assets/stylesheets/events/index.css
@@ -105,6 +105,7 @@
 /* イベント一覧 */
 .title-container {
   margin-top: 100px;
+  width: 150%;
 }
 
 .loggedin-title-container {
@@ -279,14 +280,19 @@
     margin-bottom: 50px;
   }
 
+  .title-container {
+    margin-top: 100px;
+    width: 150%;
+  }
+
   .feature-container {
     display: inline-block;
     margin: 100px auto 50px;
     width: 400px;
   }
 
-  .title-container {
-    margin-top: 100px;
+  .loggedin-title-container {
+    margin-top: 200px;
     width: 150%;
   }
 
@@ -408,6 +414,11 @@
 
   .title-container {
     margin-top: 100px;
+    width: 160%;
+  }
+
+  .loggedin-title-container {
+    margin-top: 200px;
     width: 160%;
   }
 

--- a/app/assets/stylesheets/events/index.css
+++ b/app/assets/stylesheets/events/index.css
@@ -105,7 +105,6 @@
 /* イベント一覧 */
 .title-container {
   margin-top: 100px;
-  width: 150%;
 }
 
 .loggedin-title-container {
@@ -119,7 +118,6 @@
   justify-content: center;
   margin: 100px;
   height: auto;
-  width: 140%;
 }
 
 /* イベント情報が１つだけの場合 */
@@ -262,7 +260,6 @@
 /* レスポンシブ対応（スマホ版） */
 @media screen and (max-width: 991px){
   .summary-container {
-    width: 150%;
     padding-top: 200px;
     padding-bottom: 100px;
     color: var(--theme_color);
@@ -283,7 +280,6 @@
 
   .title-container {
     margin-top: 100px;
-    width: 150%;
   }
 
   .feature-container {
@@ -294,14 +290,12 @@
 
   .loggedin-title-container {
     margin-top: 200px;
-    width: 150%;
   }
 
   .event-list-container {
     display: flex;
     flex-direction: column;
     margin: 100px auto;
-    width: 150%;
   }
 
   .card {
@@ -406,7 +400,6 @@
 /* レスポンシブ対応（iPhoneSE） */
 @media screen and (max-width: 399px){
   .summary-container {
-    width: 160%;
     padding-top: 200px;
     padding-bottom: 100px;
     color: var(--theme_color);
@@ -415,18 +408,15 @@
 
   .title-container {
     margin-top: 100px;
-    width: 160%;
   }
 
   .loggedin-title-container {
     margin-top: 200px;
-    width: 160%;
   }
 
   .event-list-container {
     display: flex;
     flex-direction: column;
-    width: 160%;
     margin: 100px auto;
   }
 
@@ -458,7 +448,6 @@
 
 /* イベント情報がない場合 */
 .not-event-title {
-  width: 150%;
   height: 500px;
   margin-top: 50px;
   text-align: center;

--- a/app/assets/stylesheets/events/index.css
+++ b/app/assets/stylesheets/events/index.css
@@ -119,6 +119,7 @@
   justify-content: center;
   margin: 100px;
   height: auto;
+  width: 140%;
 }
 
 /* イベント情報が１つだけの場合 */
@@ -453,4 +454,13 @@
   .trash-button:hover {
     opacity: 0.7;
   }
+}
+
+/* イベント情報がない場合 */
+.not-event-title {
+  width: 150%;
+  height: 500px;
+  margin-top: 50px;
+  text-align: center;
+  font-size: 1.5rem;
 }

--- a/app/assets/stylesheets/events/manage_index.css
+++ b/app/assets/stylesheets/events/manage_index.css
@@ -1,0 +1,31 @@
+.not-event-list-container {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  margin: 50px auto;
+  width: 150%;
+}
+
+.not-manage-event-title {
+  font-size: 1.5rem;
+}
+
+.transition-guidance {
+  margin-bottom: 0;
+  font-size: 1rem;
+}
+
+.transition-event-create {
+  display: grid;
+  justify-content: center;
+  width: 150%;
+}
+
+.transition-event-create-button {
+  display: flex;
+  justify-content: center;
+}
+
+
+

--- a/app/assets/stylesheets/events/manage_index.css
+++ b/app/assets/stylesheets/events/manage_index.css
@@ -4,7 +4,6 @@
   flex-direction: column;
   align-items: center;
   margin: 50px auto;
-  width: 150%;
 }
 
 .not-manage-event-title {
@@ -19,7 +18,6 @@
 .transition-event-create {
   display: grid;
   justify-content: center;
-  width: 150%;
 }
 
 .transition-event-create-button {

--- a/app/assets/stylesheets/events/pagination.css
+++ b/app/assets/stylesheets/events/pagination.css
@@ -3,7 +3,6 @@
   position: relative !important;
   bottom: 50px !important;
   margin: 100px auto !important;
-  width: 155%;
 }
 
 ul.pagination li.page-link, li.active.page-link {
@@ -33,14 +32,14 @@ ul.pagination li.page-link, li.active.page-link {
 
 /* レスポンシブ対応（スマホ版） */
 @media screen and (max-width: 991px){
-  .pagination {
+  /* .pagination {
     width: 150%;
-  }
+  } */
 }
 
 /* レスポンシブ対応（iPhoneSE） */
 @media screen and (max-width: 399px){
-  .pagination {
+  /* .pagination {
     width: 160%;
-  }
+  } */
 }

--- a/app/assets/stylesheets/events/pagination.css
+++ b/app/assets/stylesheets/events/pagination.css
@@ -3,6 +3,7 @@
   position: relative !important;
   bottom: 50px !important;
   margin: 100px auto !important;
+  width: 155%;
 }
 
 ul.pagination li.page-link, li.active.page-link {

--- a/app/assets/stylesheets/events/pagination.css
+++ b/app/assets/stylesheets/events/pagination.css
@@ -29,17 +29,3 @@ ul.pagination li.page-link, li.active.page-link {
   color: var(--white) !important;
   background-color: var(--theme_color) !important;
 }
-
-/* レスポンシブ対応（スマホ版） */
-@media screen and (max-width: 991px){
-  /* .pagination {
-    width: 150%;
-  } */
-}
-
-/* レスポンシブ対応（iPhoneSE） */
-@media screen and (max-width: 399px){
-  /* .pagination {
-    width: 160%;
-  } */
-}

--- a/app/assets/stylesheets/login.css
+++ b/app/assets/stylesheets/login.css
@@ -1,12 +1,6 @@
 @import 'bootstrap';
 
 /* ログインページ */
-.login-form-container {
-  display: grid;
-  justify-content: center;
-  margin: 200px auto;
-}
-
 .signup-link-button {
   display: inline-block;
   width: 200px;

--- a/app/assets/stylesheets/shared/common.css
+++ b/app/assets/stylesheets/shared/common.css
@@ -96,6 +96,7 @@ select {
 /* ファイルアップロードボタン（ユーザー用） */
 .upload-button{
   width: 140px;
+  margin-right: 20px;
   font-size: 14px;
   line-height: 17px;
 }

--- a/app/assets/stylesheets/shared/common.css
+++ b/app/assets/stylesheets/shared/common.css
@@ -193,6 +193,7 @@ input[type='file'] {
   cursor: pointer;
   border: 1px solid rgb(191, 194, 199);
   border-radius: 0.38rem;
+  margin-left: 16px;
   padding-right: 0.5rem;
   width: 7rem;
 }

--- a/app/assets/stylesheets/shared/common.css
+++ b/app/assets/stylesheets/shared/common.css
@@ -105,7 +105,7 @@ select {
   width: 140px;
   margin-right: 20px;
   font-size: 14px;
-  line-height: 17px;
+  line-height: 20px;
 }
 
 /* プレビュー画像（ユーザー用） */
@@ -178,4 +178,37 @@ select {
     opacity: 1;
     visibility: visible;
   }
+}
+
+/* ファイル選択ボタン */
+.image-button-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 20px auto 50px;
+}
+
+input[type='file'] {
+  color: rgb(31, 41, 55);
+  cursor: pointer;
+  border: 1px solid rgb(191, 194, 199);
+  border-radius: 0.38rem;
+  padding-right: 0.5rem;
+  width: 7rem;
+}
+
+::file-selector-button,
+::-webkit-file-upload-button {
+  background-color: rgb(209, 213, 219);
+  color: rgb(31, 41, 55);
+  border: none;
+  cursor: pointer;
+  border-right: 1px solid rgb(191, 194, 199);
+  padding: 0.3rem 0.8rem 0.3rem 0.3rem;
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+input[type='file']:hover {
+  opacity: 0.8;
 }

--- a/app/assets/stylesheets/shared/common.css
+++ b/app/assets/stylesheets/shared/common.css
@@ -2,7 +2,7 @@
 .form-container {
   display: grid;
   justify-content: center;
-  margin: 200px auto;
+  margin: 100px auto;
 }
 
 /* ページタイトル */
@@ -179,6 +179,10 @@ select {
     opacity: 1;
     visibility: visible;
   }
+
+  .form-breadcrumbs {
+    margin: 80px 0 0 20px;
+  }
 }
 
 /* ファイル選択ボタン */
@@ -213,4 +217,42 @@ input[type='file'] {
 
 input[type='file']:hover {
   opacity: 0.8;
+}
+
+/* パンくずリスト */
+.breadcrumbs {
+  margin: 50px 0 0 20px;
+}
+
+.loggedin-breadcrumbs,
+.form-breadcrumbs {
+  margin: 130px 0 0 20px;
+}
+
+.breadcrumbs > a,
+.loggedin-breadcrumbs > a,
+.form-breadcrumbs > a {
+  color: var(--theme_color);
+}
+
+.breadcrumbs > a:hover,
+.loggedin-breadcrumbs > a:hover,
+.form-breadcrumbs > a:hover {
+  opacity: 0.7;
+}
+
+/* レスポンシブ対応（スマホ版） */
+@media screen and (max-width: 991px){
+  .loggedin-breadcrumbs,
+  .form-breadcrumbs {
+    margin: 100px 0 0 20px;
+  }
+}
+
+/* レスポンシブ対応（iPhoneSE） */
+@media screen and (max-width: 399px){
+  .loggedin-breadcrumbs,
+  .form-breadcrumbs {
+    margin: 100px 0 0 20px;
+  }
 }

--- a/app/assets/stylesheets/shared/modal.css
+++ b/app/assets/stylesheets/shared/modal.css
@@ -1,0 +1,36 @@
+.modal {
+  --bs-modal-header-border-width: none !important;
+  --bs-modal-footer-border-color: none !important;
+}
+
+/* 削除ボタン */
+.modal-footer > .btn-primary,
+.image-button-container > .btn-primary {
+  --bs-btn-color: var(--white) !important;
+  --bs-btn-bg: var(--red) !important;
+  --bs-btn-border-color: var(--red) !important;
+  --bs-btn-active-bg: var(--red) !important;
+  --bs-btn-active-border-color: var(--red) !important;
+  --bs-btn-disabled-bg: var(--red) !important;
+  --bs-btn-disabled-border-color: var(--red) !important;
+}
+
+.image-button-container > .btn-primary {
+  font-size: 0.8rem;
+}
+
+.modal-footer > .btn.btn-primary:hover,
+.image-button-container > .btn.btn-primary:hover {
+  --bs-btn-color: var(--white) !important;
+  --bs-btn-bg: var(--red) !important;
+  --bs-btn-border-color: var(--red) !important;
+  opacity: 0.8 !important;
+}
+
+.modal-footer > .btn.outline:hover,
+.image-button-container > .btn.outline:hover {
+  color: var(--white);
+  background-color: var(--red);
+  border: 1px solid var(--red);
+  opacity: 0.8;
+}

--- a/app/assets/stylesheets/shared/modal.css
+++ b/app/assets/stylesheets/shared/modal.css
@@ -13,6 +13,8 @@
   --bs-btn-active-border-color: var(--red) !important;
   --bs-btn-disabled-bg: var(--red) !important;
   --bs-btn-disabled-border-color: var(--red) !important;
+  --bs-btn-hover-bg: var(--red) !important;
+  --bs-btn-hover-border-color: var(--red) !important;
 }
 
 .image-button-container > .btn-primary {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
   protect_from_forgery with: :exception
+  add_breadcrumb 'Top <i class="fa fa-home" aria-hidden="true"></i>'.html_safe, '/'
 
   protected
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -54,7 +54,11 @@ class EventsController < ApplicationController
       end
 
       if @event.save
-        redirect_to manage_events_path, notice: 'イベントを更新しました'
+        if params[:event][:public_status] == 'open'
+          redirect_to(root_path, notice: 'イベントを更新しました')
+        else
+          redirect_to(root_path, notice: '非公開イベントを更新しました')
+        end
       else
         flash.now[:alert] = 'イベントの更新に失敗しました'
         render action: 'edit', status: 400

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -28,6 +28,22 @@ class EventsController < ApplicationController
     @event = Event.new
   end
 
+  def edit
+    @event = Event.find(params[:id])
+  end
+
+  def update
+    @event = Event.find(params[:id])
+    @event.update(event_params)
+    if @event.save
+      redirect_to manage_events_path, notice: 'イベントを更新しました'
+    else
+      flash.now[:alert] = 'イベントの更新に失敗しました'
+      render action: 'edit', status: 400
+    end
+  end
+
+
   def manage_events
     if params[:category_id]
       category_id = Category.find_by(id: params[:category_id])

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -5,9 +5,9 @@ class EventsController < ApplicationController
   def index
     if params[:category_id]
       category_id = Category.find_by(id: params[:category_id])
-      @events = Event.where(category_id: category_id).where(public_status: 1).order(updated_at: "DESC").page(params[:page])
+      @events = Event.where(category_id: category_id, public_status: 1).order(updated_at: "DESC").page(params[:page])
     elsif params[:event_day]
-      @events = Event.where(event_day: params[:event_day]).where(public_status: 1).order(updated_at: "DESC").page(params[:page])
+      @events = Event.where(event_day: params[:event_day], public_status: 1).order(updated_at: "DESC").page(params[:page])
     else
       @events = Event.includes(:category).where(public_status: 1).order(updated_at: "DESC").page(params[:page])
     end
@@ -20,6 +20,7 @@ class EventsController < ApplicationController
     if @event.save
       redirect_to(root_path, notice: 'イベントを作成しました')
     else
+      flash.now[:alert] = 'イベントの作成に失敗しました'
       render action: 'new', status:400
     end
   end
@@ -47,9 +48,9 @@ class EventsController < ApplicationController
   def manage_events
     if params[:category_id]
       category_id = Category.find_by(id: params[:category_id])
-      @manage_events = Event.where(user_id: current_user).where(category_id: category_id).order(updated_at: "DESC").page(params[:page])
+      @manage_events = Event.where(user_id: current_user, category_id: category_id).order(updated_at: "DESC").page(params[:page])
     elsif params[:event_day]
-      @manage_events = Event.where(user_id: current_user).where(event_day: params[:event_day]).order(updated_at: "DESC").page(params[:page])
+      @manage_events = Event.where(user_id: current_user, event_day: params[:event_day]).order(updated_at: "DESC").page(params[:page])
     else
       @manage_events = Event.where(user_id: current_user).order(updated_at: "DESC").page(params[:page])
     end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -35,12 +35,15 @@ class EventsController < ApplicationController
 
   def update
     @event = Event.find(params[:id])
-    @event.update(event_params)
-    if @event.save
-      redirect_to manage_events_path, notice: 'イベントを更新しました'
-    else
-      flash.now[:alert] = 'イベントの更新に失敗しました'
-      render action: 'edit', status: 400
+    ApplicationRecord.transaction do
+      delete_image
+      @event.update(event_params)
+      if @event.save
+        redirect_to manage_events_path, notice: 'イベントを更新しました'
+      else
+        flash.now[:alert] = 'イベントの更新に失敗しました'
+        render action: 'edit', status: 400
+      end
     end
   end
 
@@ -57,6 +60,10 @@ class EventsController < ApplicationController
   end
 
   private
+
+  def delete_image
+    @event.image.purge
+  end
 
   def event_params
     params.require(:event).permit(:name, :event_description, :event_day, :public_status, :image, :category_id)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,7 @@
 class EventsController < ApplicationController
   skip_before_action :require_login, only: [:index]
   before_action :require_login, only: [:create, :new, :manage_events]
+  before_action :set_event, only: [:update]
 
   def index
     if params[:category_id]
@@ -34,10 +35,13 @@ class EventsController < ApplicationController
   end
 
   def update
-    @event = Event.find(params[:id])
     ApplicationRecord.transaction do
-      delete_image
+      if params[:event][:delete_image] == 'true'
+        @event.image.purge
+      end
+
       @event.update(event_params)
+
       if @event.save
         redirect_to manage_events_path, notice: 'イベントを更新しました'
       else
@@ -61,11 +65,11 @@ class EventsController < ApplicationController
 
   private
 
-  def delete_image
-    @event.image.purge
+  def set_event
+    @event = Event.find(params[:id])
   end
 
   def event_params
-    params.require(:event).permit(:name, :event_description, :event_day, :public_status, :image, :category_id)
+    params.require(:event).permit(:name, :event_description, :event_day, :public_status, :image, :category_id, :delete_image)
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -5,11 +5,11 @@ class EventsController < ApplicationController
   def index
     if params[:category_id]
       category_id = Category.find_by(id: params[:category_id])
-      @events = Event.where(category_id: category_id).order(updated_at: "DESC").page(params[:page])
+      @events = Event.where(category_id: category_id).where(public_status: 1).order(updated_at: "DESC").page(params[:page])
     elsif params[:event_day]
-      @events = Event.where(event_day: params[:event_day]).order(updated_at: "DESC").page(params[:page])
+      @events = Event.where(event_day: params[:event_day]).where(public_status: 1).order(updated_at: "DESC").page(params[:page])
     else
-      @events = Event.includes(:category).order(updated_at: "DESC").page(params[:page])
+      @events = Event.includes(:category).where(public_status: 1).order(updated_at: "DESC").page(params[:page])
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < ApplicationController
   skip_before_action :require_login, only: [:new, :create]
+  before_action :login_breadcrumb
 
   def create
     @user = login(params[:email], params[:password])
@@ -19,5 +20,11 @@ class SessionsController < ApplicationController
   def destroy
     logout
     redirect_to(login_path, notice: 'ログアウトしました')
+  end
+
+  private
+
+  def login_breadcrumb
+    add_breadcrumb 'ログイン', login_path
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,8 +5,9 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       session[:user_id] = @user.id
-      redirect_to(root_path, notice: 'ユーザーを作成しました')
+      redirect_to(root_path, notice: 'ユーザーを登録しました')
     else
+      flash.now[:alert] = 'ユーザーの登録に失敗しました'
       render action: 'new'
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   skip_before_action :require_login, only: [:new, :create]
+  before_action :regist_breadcrumb, only: [:new, :create]
 
   def create
     ApplicationRecord.transaction do
@@ -24,6 +25,10 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def regist_breadcrumb
+    add_breadcrumb 'ユーザー新規登録', new_user_path
+  end
 
   def user_params
     params.require(:user).permit(:name, :email, :password, :phone_number, :self_introduction, :image, :delete_image)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,13 +2,20 @@ class UsersController < ApplicationController
   skip_before_action :require_login, only: [:new, :create]
 
   def create
-    @user = User.new(user_params)
-    if @user.save
-      session[:user_id] = @user.id
-      redirect_to(root_path, notice: 'ユーザーを登録しました')
-    else
-      flash.now[:alert] = 'ユーザーの登録に失敗しました'
-      render action: 'new'
+    ApplicationRecord.transaction do
+      @user = User.new(user_params)
+
+      if params[:user][:delete_image] == 'true'
+        @user.image.purge
+      end
+
+      if @user.save
+        session[:user_id] = @user.id
+        redirect_to(root_path, notice: 'ユーザーを登録しました')
+      else
+        flash.now[:alert] = 'ユーザーの登録に失敗しました'
+        render action: 'new'
+      end
     end
   end
 
@@ -19,6 +26,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :phone_number, :self_introduction, :image)
+    params.require(:user).permit(:name, :email, :password, :phone_number, :self_introduction, :image, :delete_image)
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,7 @@
 import "bootstrap"
 import "@hotwired/turbo-rails"
 import "controllers"
+import "./preview"
 
 $(function() {
   $('.flash-message').fadeOut(5000);

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -2,6 +2,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const fileInput = document.getElementById('image-upload');
   const imagePreview = document.getElementById('image-preview') || document.getElementById('event-image-preview');
+  const deleteImageField = document.getElementById('delete_image_field');
 
   imagePreview.addEventListener('click', () => {
     fileInput.click();
@@ -14,6 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const reader = new FileReader();
       reader.onload = (e) => {
         imagePreview.src = e.target.result;
+        deleteImageField.checked = false;
       };
       reader.readAsDataURL(file);
     }

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+
+  const fileInput = document.getElementById('image-upload');
+  const imagePreview = document.getElementById('image-preview') || document.getElementById('event-image-preview');
+
+  imagePreview.addEventListener('click', () => {
+    fileInput.click();
+  });
+
+  fileInput.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        imagePreview.src = e.target.result;
+      };
+      reader.readAsDataURL(file);
+    }
+  });
+});

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,0 +1,101 @@
+<div class="flash-message-container">
+  <%= render 'shared/flash_message' %>
+</div>
+
+<% if logged_in? %>
+  <div class="form-container">
+    <h1 class="title">イベント編集</h1>
+    <%= form_with model: @event, method: :patch do |f| %>
+      <div class="mt-4 mb-4">
+        <%= f.label "イベント名", class:"label-tag fw-bold" %><br />
+        <%= f.text_field :name, placeholder:"例）○○交流会", class:"name-field p-2" %>
+        <% if @event.errors[:name].any? %>
+          <div class="error-message mt-1">
+            <%= safe_join(@event.errors[:name]) %>
+          </div>
+        <% end %>
+      </div>
+      <div class="mt-4 mb-4">
+        <%= f.label "イベントの説明", class:"label-tag fw-bold" %><br />
+        <%= f.text_area :event_description, placeholder:"イベントの説明文を入力", rows: 5, class: "text-area w-100 p-2" %>
+        <% if @event.errors[:event_description].any? %>
+          <div class="error-message mt-1">
+            <%= safe_join(@event.errors[:event_description]) %>
+          </div>
+        <% end %>
+      </div>
+      <div class="mt-4 mb-4">
+        <%= f.label "カテゴリー", class:"label-tag fw-bold" %><br />
+        <%= f.collection_select :category_id, Category.all, :id, :name, include_blank: "選択してください", class:"form-control" %>
+        <% if @event.errors[:category_id].any? %>
+          <div class="error-message mt-1">
+            <%= safe_join(@event.errors[:category_id]) %>
+          </div>
+        <% end %>
+      </div>
+      <div class="mt-4 mb-4">
+        <%= f.label "開催日", class:"label-tag fw-bold" %><br />
+        <%= f.date_field :event_day, class:"form-control-sm", min: Date.current %>
+        <% if @event.errors[:event_day].any? %>
+          <div class="error-message mt-1">
+            <%= safe_join(@event.errors[:event_day]) %>
+          </div>
+        <% end %>
+      </div>
+      <div class="mt-4 mb-4">
+        <%= f.label "イベントの公開設定", class:"label-tag fw-bold mr-2" %><br />
+        <div class="radio-button-items d-flex align-items-center">
+          <%= f.label "公開", class:"radio-label-tag" %><br />
+          <%= f.radio_button :public_status, :open, class:"radio-button", checked: true %><br />
+          <%= f.label "非公開", class:"radio-label-tag" %><br />
+          <%= f.radio_button :public_status, :closed, class:"radio-button" %>
+        </div>
+        <% if @event.errors[:public_status].any? %>
+          <div class="error-message mt-1">
+            <%= safe_join(@event.errors[:public_status]) %>
+          </div>
+        <% end %>
+      </div>
+      <div class="image-field mt-4 mb-5" data-turbo="false">
+        <%= f.label "イベント画像", class: "label-tag fw-bold" %><br />
+        <div class="speech-bubble-area">
+          <p class="speech-bubble">画像をクリックして、ファイルを選択できます。</p>
+          <img id="event-image-preview" src="<%= url_for(@event.image) %>" class="mt-2 mb-2" /><br />
+        </div>
+      </div>
+      <%= f.file_field :image, class: "event-upload-button invisible", id: "image-upload" %>
+      <div class="actions">
+        <%= f.submit "イベント更新", class: "submit-button", data: { turbo: false } %>
+      </div>
+      <div class="back-button-container mt-3">
+        <%= link_to 'イベント管理に戻る', manage_events_path, class:"back-button", data: { turbo: false } %>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+
+  const fileInput = document.getElementById('image-upload');
+  const imagePreview = document.getElementById('event-image-preview');
+
+  imagePreview.addEventListener('click', () => {
+    fileInput.click();
+  });
+
+  fileInput.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        imagePreview.src = e.target.result;
+      };
+      reader.readAsDataURL(file);
+    } else {
+      imagePreview.src = 'app/assets/images/events/no_image.png';
+    }
+  });
+});
+</script>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -4,6 +4,7 @@
 
 <% if logged_in? %>
   <%= render 'shared/modal' %>
+  <%= render 'shared/delete_image' %>
   <div class="form-container">
     <h1 class="title">イベント編集</h1>
     <%= form_with model: @event, method: :patch do |f| %>
@@ -84,22 +85,3 @@
     <% end %>
   </div>
 <% end %>
-
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  const imageDeleteButton = document.getElementById('image-delete-button');
-  const imageDelete = document.getElementById('image-delete');
-  const deleteImageField = document.getElementById('delete_image_field');
-  const imagePreview = document.getElementById('image-preview') || document.getElementById('event-image-preview');
-
-  imageDelete.addEventListener('click', () => {
-
-    deleteImageField.checked = true;
-
-    imagePreview.src = '<%= asset_path("events/no_image.png") %>';
-
-  })
-});
-
-
-</script>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -5,6 +5,10 @@
 <% if logged_in? %>
   <%= render 'shared/modal' %>
   <%= render 'shared/delete_image' %>
+  <div class="form-breadcrumbs">
+    <%= render_breadcrumbs separator: ' > ' %>
+  </div>
+
   <div class="form-container">
     <h1 class="title">イベント編集</h1>
     <%= form_with model: @event, method: :patch do |f| %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -60,10 +60,19 @@
         <%= f.label "イベント画像", class: "label-tag fw-bold" %><br />
         <div class="speech-bubble-area">
           <p class="speech-bubble">画像をクリックして、ファイルを選択できます。</p>
-          <img id="event-image-preview" src="<%= url_for(@event.image) %> : <%= asset_path("events/no_image.png") %>", class="mt-2 mb-2" /><br />
+          <% if @event.image.attached? %>
+            <img id="event-image-preview" src="<%= url_for(@event.image) %>", class="mt-2 mb-2" /><br />
+          <% else %>
+            <img id="event-image-preview" src="<%= asset_path("events/no_image.png") %>", class="mt-2 mb-2" /><br />
+          <% end %>
         </div>
       </div>
-      <%= f.file_field :image, class: "event-upload-button invisible", id: "image-upload" %>
+      <div class="image-button-container">
+        <%= f.file_field :image, class: "event-upload-button", id: "image-upload" %>
+        <%= link_to '画像を削除する', delete_image_event_path(@event), data: { turbo_method: :delete }, id: "image-delete-button",
+          class: "hover: text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow text-decoration-none"
+        %>
+      </div>
       <div class="actions">
         <%= f.submit "イベント更新", class: "submit-button", data: { turbo: false } %>
       </div>
@@ -73,3 +82,15 @@
     <% end %>
   </div>
 <% end %>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+
+  const imageDeleteButton = document.getElementById('image-delete-button');
+  const imagePreview = document.getElementById('image-preview') || document.getElementById('event-image-preview');
+
+  imageDeleteButton.addEventListener('click', () => {
+    imagePreview.src = '<%= asset_path("events/no_image.png") %>';
+  });
+});
+</script>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="flash-message-container">
+<div class="form-flash-message-container">
   <%= render 'shared/flash_message' %>
 </div>
 

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="form-flash-message-container">
+<div class="flash-message-container">
   <%= render 'shared/flash_message' %>
 </div>
 

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -60,7 +60,7 @@
         <%= f.label "イベント画像", class: "label-tag fw-bold" %><br />
         <div class="speech-bubble-area">
           <p class="speech-bubble">画像をクリックして、ファイルを選択できます。</p>
-          <img id="event-image-preview" src="<%= url_for(@event.image) %>" class="mt-2 mb-2" /><br />
+          <img id="event-image-preview" src="<%= url_for(@event.image) %> : <%= asset_path("events/no_image.png") %>", class="mt-2 mb-2" /><br />
         </div>
       </div>
       <%= f.file_field :image, class: "event-upload-button invisible", id: "image-upload" %>
@@ -73,29 +73,3 @@
     <% end %>
   </div>
 <% end %>
-
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-
-  const fileInput = document.getElementById('image-upload');
-  const imagePreview = document.getElementById('event-image-preview');
-
-  imagePreview.addEventListener('click', () => {
-    fileInput.click();
-  });
-
-  fileInput.addEventListener('change', (e) => {
-    const file = e.target.files[0];
-
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        imagePreview.src = e.target.result;
-      };
-      reader.readAsDataURL(file);
-    } else {
-      imagePreview.src = 'app/assets/images/events/no_image.png';
-    }
-  });
-});
-</script>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -3,6 +3,7 @@
 </div>
 
 <% if logged_in? %>
+  <%= render 'shared/modal' %>
   <div class="form-container">
     <h1 class="title">イベント編集</h1>
     <%= form_with model: @event, method: :patch do |f| %>
@@ -69,9 +70,10 @@
       </div>
       <div class="image-button-container">
         <%= f.file_field :image, class: "event-upload-button", id: "image-upload" %>
-        <%= link_to '画像を削除する', delete_image_event_path(@event), data: { turbo_method: :delete }, id: "image-delete-button",
-          class: "hover: text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow text-decoration-none"
-        %>
+        <button type="button" id="image-delete-button" class="btn outline btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal">
+          画像を削除
+        </button>
+        <%= f.check_box :delete_image, { class: "form-check-input invisible", id: 'delete_image_field', checked: false }, true, false %>
       </div>
       <div class="actions">
         <%= f.submit "イベント更新", class: "submit-button", data: { turbo: false } %>
@@ -85,12 +87,19 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-
   const imageDeleteButton = document.getElementById('image-delete-button');
+  const imageDelete = document.getElementById('image-delete');
+  const deleteImageField = document.getElementById('delete_image_field');
   const imagePreview = document.getElementById('image-preview') || document.getElementById('event-image-preview');
 
-  imageDeleteButton.addEventListener('click', () => {
+  imageDelete.addEventListener('click', () => {
+
+    deleteImageField.checked = true;
+
     imagePreview.src = '<%= asset_path("events/no_image.png") %>';
-  });
+
+  })
 });
+
+
 </script>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -37,7 +37,11 @@
   <% for event in @events do %>
     <div class="card shadow p-3 mb-5 bg-white rounded">
       <div class="card__inner">
-        <%= image_tag event.image, class:"card__image", size:'300x300' %>
+        <% if event.image.attached? %>
+          <%= image_tag event.image, class:"card__image" %>
+        <% else %>
+          <%= image_tag 'events/no_image.png', class:"card__image" %>
+        <% end %>
         <div class="card__textbox">
           <div class="card__title">
             <%= event.name.truncate(33) %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -33,30 +33,34 @@
   <h1 class="title">イベント一覧</h1>
 </div>
 
-<div class="event-list-container <%= @events.size == 1 ? 'card-one' : '' %>">
-  <% for event in @events do %>
-    <div class="card shadow p-3 mb-5 bg-white rounded">
-      <div class="card__inner">
-        <% if event.image.attached? %>
-          <%= image_tag event.image, class:"card__image" %>
-        <% else %>
-          <%= image_tag 'events/no_image.png', class:"card__image" %>
-        <% end %>
-        <div class="card__textbox">
-          <div class="card__title">
-            <%= event.name.truncate(33) %>
-          </div>
-          <div class="card__items">
-            <%= link_to category_events_path(category_id: event.category.id), class: "category-label", data: { turbo:false } do %>
-              <%= event.category.name.truncate(18) %>
-            <% end %>
-            <%= link_to date_events_path(event_day: event.event_day), class:"eventday-container", data: { turbo:false } do %>
-              <p class="eventday-label">開催日:<span class="eventday-value"><%= event.event_day.strftime("%-m月%-d日") %></span></p>
-            <% end %>
+<% if @events.present? %>
+  <div class="event-list-container <%= @events.size == 1 ? 'card-one' : '' %>">
+    <% for event in @events do %>
+      <div class="card shadow p-3 mb-5 bg-white rounded">
+        <div class="card__inner">
+          <% if event.image.attached? %>
+            <%= image_tag event.image, class:"card__image" %>
+          <% else %>
+            <%= image_tag 'events/no_image.png', class:"card__image" %>
+          <% end %>
+          <div class="card__textbox">
+            <div class="card__title">
+              <%= event.name.truncate(33) %>
+            </div>
+            <div class="card__items">
+              <%= link_to category_events_path(category_id: event.category.id), class: "category-label", data: { turbo:false } do %>
+                <%= event.category.name.truncate(18) %>
+              <% end %>
+              <%= link_to date_events_path(event_day: event.event_day), class:"eventday-container", data: { turbo:false } do %>
+                <p class="eventday-label">開催日:<span class="eventday-value"><%= event.event_day.strftime("%-m月%-d日") %></span></p>
+              <% end %>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  <% end %>
-</div>
-<%= paginate @events, theme: 'bootstrap-5', pagination_class: "mt-4 pagination-sm flex-wrap justify-content-center" %>
+    <% end %>
+  </div>
+  <%= paginate @events, theme: 'bootstrap-5', pagination_class: "mt-4 pagination-sm flex-wrap justify-content-center" %>
+<% else %>
+  <h1  class="not-event-title">登録されたイベント情報がありません。</h1>
+ <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -29,7 +29,11 @@
   </section>
 <% end %>
 
-<div class="title-container <%= logged_in? ? 'loggedin-title-container' : '' %>">
+<div class="breadcrumbs <%= logged_in? ? 'loggedin-breadcrumbs' : '' %>">
+  <%= render_breadcrumbs separator: ' > ' %>
+</div>
+
+<div class="title-container">
   <h1 class="title">イベント一覧</h1>
 </div>
 

--- a/app/views/events/manage_events.html.erb
+++ b/app/views/events/manage_events.html.erb
@@ -7,39 +7,51 @@
     <h1 class="title">イベント管理</h1>
   </div>
 
-  <div class="event-list-container <%= @manage_events.size == 1 ? 'card-one' : '' %>">
-    <% @manage_events.each do |event| %>
-      <div class="card shadow p-3 mb-5 bg-white rounded">
-        <div class="card__inner">
-          <% if event.image.attached? %>
-            <%= image_tag event.image, class:"card__image" %>
-          <% else %>
-            <%= image_tag 'events/no_image.png', class:"card__image" %>
-          <% end %>
-          <div class="card__textbox">
-            <div class="card__title">
-              <%= event.name.truncate(33) %>
-            </div>
-            <div class="card__items">
-              <%= link_to manage_category_events_path(category_id: event.category.id), class: "category-label", data: { turbo:false } do %>
-                <%= event.category.name.truncate(18) %>
-              <% end %>
-              <%= link_to manage_date_events_path(event_day: event.event_day), class:"eventday-container", data: { turbo:false } do %>
-                <p class="eventday-label">開催日:<span class="eventday-value"><%= event.event_day.strftime("%-m月%-d日") %></span></p>
-              <% end %>
-              <div class="card__button">
-                <%= link_to edit_event_path(event), class: 'edit-button text-dark', data: { turbo: false } do %>
-                  <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
+  <% if @manage_events.present? %>
+    <div class="event-list-container <%= @manage_events.size == 1 ? 'card-one' : '' %>">
+      <% @manage_events.each do |event| %>
+        <div class="card shadow p-3 mb-5 bg-white rounded">
+          <div class="card__inner">
+            <% if event.image.attached? %>
+              <%= image_tag event.image, class:"card__image" %>
+            <% else %>
+              <%= image_tag 'events/no_image.png', class:"card__image" %>
+            <% end %>
+            <div class="card__textbox">
+              <div class="card__title">
+                <%= event.name.truncate(33) %>
+              </div>
+              <div class="card__items">
+                <%= link_to manage_category_events_path(category_id: event.category.id), class: "category-label", data: { turbo:false } do %>
+                  <%= event.category.name.truncate(18) %>
                 <% end %>
-                <%= link_to "events/#{event.id}", class: 'trash-button text-dark', data: { turbo: false } do %>
-                  <i class="fa fa-trash" aria-hidden="true"></i>
+                <%= link_to manage_date_events_path(event_day: event.event_day), class:"eventday-container", data: { turbo:false } do %>
+                  <p class="eventday-label">開催日:<span class="eventday-value"><%= event.event_day.strftime("%-m月%-d日") %></span></p>
                 <% end %>
+                <div class="card__button">
+                  <%= link_to edit_event_path(event), class: 'edit-button text-dark', data: { turbo: false } do %>
+                    <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
+                  <% end %>
+                  <%= link_to "events/#{event.id}", class: 'trash-button text-dark', data: { turbo: false } do %>
+                    <i class="fa fa-trash" aria-hidden="true"></i>
+                  <% end %>
+                </div>
               </div>
             </div>
           </div>
         </div>
+      <% end %>
+    </div>
+    <%= paginate @manage_events, theme: 'bootstrap-5', pagination_class: "mt-4 pagination-sm flex-wrap justify-content-center" %>]
+  <% else %>
+    <div class="not-event-list-container">
+      <h1  class="not-manage-event-title">登録されたイベント情報がありません。</h1><br />
+      <div class="transition-event-create">
+        <h2 class="transition-guidance">イベントの作成はこちらのボタンから</h2><br />
+        <a href="/events/new" class="transition-event-create-button text-decoration-none" data-turbo="false">
+          <span class="button-text">イベント作成</span>
+        </a>
       </div>
-    <% end %>
-  </div>
-  <%= paginate @manage_events, theme: 'bootstrap-5', pagination_class: "mt-4 pagination-sm flex-wrap justify-content-center" %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/events/manage_events.html.erb
+++ b/app/views/events/manage_events.html.erb
@@ -11,7 +11,11 @@
     <% @manage_events.each do |event| %>
       <div class="card shadow p-3 mb-5 bg-white rounded">
         <div class="card__inner">
-          <%= image_tag event.image, class:"card__image", size:'300x300' %>
+          <% if event.image.attached? %>
+            <%= image_tag event.image, class:"card__image" %>
+          <% else %>
+            <%= image_tag 'events/no_image.png', class:"card__image" %>
+          <% end %>
           <div class="card__textbox">
             <div class="card__title">
               <%= event.name.truncate(33) %>

--- a/app/views/events/manage_events.html.erb
+++ b/app/views/events/manage_events.html.erb
@@ -3,7 +3,11 @@
 </div>
 
 <% if logged_in? %>
-  <div class="title-container <%= logged_in? ? 'loggedin-title-container' : '' %>">
+  <div class="loggedin-breadcrumbs">
+    <%= render_breadcrumbs separator: ' > ' %>
+  </div>
+
+  <div class="title-container">
     <h1 class="title">イベント管理</h1>
   </div>
 

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -3,6 +3,7 @@
 </div>
 
 <% if logged_in? %>
+  <%= render 'shared/modal' %>
   <div class="form-container">
     <h1 class="title">イベント作成</h1>
     <%= form_with model: @event, method: :post do |f| %>
@@ -63,7 +64,13 @@
           <img id="event-image-preview" src="<%= asset_path("events/no_image.png") %>", class="mt-2 mb-2" /><br />
         </div>
       </div>
-      <%= f.file_field :image, class: "event-upload-button invisible", id: "image-upload" %>
+      <div class="image-button-container">
+        <%= f.file_field :image, class: "event-upload-button", id: "image-upload" %>
+        <button type="button" id="image-delete-button" class="btn outline btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal">
+          画像を削除
+        </button>
+        <%= f.check_box :delete_image, { class: "form-check-input invisible", id: 'delete_image_field', checked: false }, true, false %>
+      </div>
       <div class="actions">
         <%= f.submit "イベント作成", class: "submit-button", data: { turbo: false } %>
       </div>
@@ -73,3 +80,4 @@
     <% end %>
   </div>
 <% end %>
+<%= render 'shared/delete_image' %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,4 +1,4 @@
-<div class="flash-message-container">
+<div class="form-flash-message-container">
   <%= render 'shared/flash_message' %>
 </div>
 

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,9 +1,10 @@
-<div class="form-flash-message-container">
+<div class="flash-message-container">
   <%= render 'shared/flash_message' %>
 </div>
 
 <% if logged_in? %>
   <%= render 'shared/modal' %>
+  <%= render 'shared/delete_image' %>
   <div class="form-container">
     <h1 class="title">イベント作成</h1>
     <%= form_with model: @event, method: :post do |f| %>
@@ -80,4 +81,3 @@
     <% end %>
   </div>
 <% end %>
-<%= render 'shared/delete_image' %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -60,7 +60,7 @@
         <%= f.label "イベント画像", class: "label-tag fw-bold" %><br />
         <div class="speech-bubble-area">
           <p class="speech-bubble">画像をクリックして、ファイルを選択できます。</p>
-          <img id="event-image-preview" src="#" class="mt-2 mb-2" /><br />
+          <img id="event-image-preview" src="<%= asset_path("events/no_image.png") %>", class="mt-2 mb-2" /><br />
         </div>
       </div>
       <%= f.file_field :image, class: "event-upload-button invisible", id: "image-upload" %>
@@ -73,37 +73,3 @@
     <% end %>
   </div>
 <% end %>
-
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-
-  const fileInput = document.getElementById('image-upload');
-  const imagePreview = document.getElementById('event-image-preview');
-
-  //画像をクリックしたらファイルアップロードボタンのクリック操作を実行する
-  imagePreview.addEventListener('click', () => {
-    fileInput.click();
-  });
-
-  window.addEventListener('DOMContentLoaded', () => {
-    const imagePreview = document.getElementById('event-image-preview');
-    //ページが読み込まれた時に、src属性にデフォルトの画像を設定して表示する
-    imagePreview.src = '<%= asset_path("events/no_image.png") %>';
-  });
-
-
-  fileInput.addEventListener('change', (e) => {
-    const file = e.target.files[0];
-
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        imagePreview.src = e.target.result;
-      };
-      reader.readAsDataURL(file);
-    } else {
-      imagePreview.src = 'app/assets/images/events/no_image.png';
-    }
-  });
-});
-</script>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -5,6 +5,10 @@
 <% if logged_in? %>
   <%= render 'shared/modal' %>
   <%= render 'shared/delete_image' %>
+  <div class="form-breadcrumbs">
+    <%= render_breadcrumbs separator: ' > ' %>
+  </div>
+
   <div class="form-container">
     <h1 class="title">イベント作成</h1>
     <%= form_with model: @event, method: :post do |f| %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -2,7 +2,11 @@
   <%= render 'shared/flash_message' %>
 </div>
 
-<div class="login-form-container">
+<div class="form-breadcrumbs">
+  <%= render_breadcrumbs separator: ' > ' %>
+</div>
+
+<div class="form-container">
   <h1 class="title">ログイン</h1>
   <%= form_with url: login_path, method: :post do |f| %>
     <div class="mt-4 mb-4">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="flash-message-container">
+<div class="form-flash-message-container">
   <%= render 'shared/flash_message' %>
 </div>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="form-flash-message-container">
+<div class="flash-message-container">
   <%= render 'shared/flash_message' %>
 </div>
 

--- a/app/views/shared/_delete_image.erb
+++ b/app/views/shared/_delete_image.erb
@@ -1,0 +1,15 @@
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const imageDeleteButton = document.getElementById('image-delete-button');
+  const imageDelete = document.getElementById('image-delete');
+  const deleteImageField = document.getElementById('delete_image_field');
+  const imagePreview = document.getElementById('image-preview') || document.getElementById('event-image-preview');
+  const fileInput = document.getElementById('image-upload');
+
+  imageDelete.addEventListener('click', () => {
+    deleteImageField.checked = true;
+    fileInput.value = '';
+    imagePreview.src = '<%= asset_path("events/no_image.png") %>';
+  })
+});
+</script>

--- a/app/views/shared/_delete_image.erb
+++ b/app/views/shared/_delete_image.erb
@@ -9,7 +9,11 @@ document.addEventListener('DOMContentLoaded', () => {
   imageDelete.addEventListener('click', () => {
     deleteImageField.checked = true;
     fileInput.value = '';
-    imagePreview.src = '<%= asset_path("events/no_image.png") %>';
+    if(document.getElementById('event-image-preview')) {
+      imagePreview.src = '<%= asset_path("events/no_image.png") %>';
+    } else {
+      imagePreview.src = '<%= asset_path("default_avatar.png") %>';
+    }
   })
 });
 </script>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,6 +6,8 @@
     <% if logged_in? %>
       <% if current_user.image.attached? %>
         <%= image_tag current_user.image, class:"header-profile-image" %>
+      <% else %>
+        <%= image_tag 'default_avatar.png', class:"header-profile-image" %>
       <% end %>
       <p class="login-user-name"><%= current_user.name.truncate(13) %>さん</p>
     <% else %>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,0 +1,17 @@
+  <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5" id="exampleModalLabel">削除確認画面</h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body exampleModal">
+        画像を削除しますか？
+      </div>
+      <div class="modal-footer">
+        <button type="button" id="image-delete-cancel" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
+        <button type="button" id="image-delete" class="btn outline btn-primary" data-bs-dismiss="modal">削除</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,6 +2,8 @@
   <%= render 'shared/flash_message' %>
 </div>
 
+<%= render 'shared/modal' %>
+<%= render 'shared/delete_image' %>
 <div class="form-container">
   <h1 class="title">ユーザー新規登録</h1>
   <%= form_with model: @user, method: :post do |f| %>
@@ -57,7 +59,13 @@
         <img id="image-preview" src="<%= asset_path("default_avatar.png") %>" class="mt-4 mb-2" /><br />
       </div>
     </div>
-    <%= f.file_field :image, class: "upload-button invisible", id: "image-upload" %><br />
+    <div class="image-button-container">
+      <%= f.file_field :image, class: "upload-button", id: "image-upload" %>
+      <button type="button" id="image-delete-button" class="btn outline btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal">
+        画像を削除
+      </button>
+      <%= f.check_box :delete_image, { class: "form-check-input invisible", id: 'delete_image_field', checked: false }, true, false %>
+    </div>
     <div class="actions">
       <%= f.submit "新規登録", class: "submit-button", data: { turbo: false } %>
     </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -54,7 +54,7 @@
       <%= f.label "プロフィール画像", class: "label-tag fw-bold" %><br />
       <div class="speech-bubble-area">
         <p class="speech-bubble">画像をクリックして、ファイルを選択できます。</p>
-        <img id="image-preview" src="#" class="mt-4 mb-2" /><br />
+        <img id="image-preview" src="<%= asset_path("default_avatar.png") %>" class="mt-4 mb-2" /><br />
       </div>
     </div>
     <%= f.file_field :image, class: "upload-button invisible", id: "image-upload" %><br />
@@ -66,36 +66,3 @@
     </div>
   <% end %>
 </div>
-
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-
-  const fileInput = document.getElementById('image-upload');
-  const imagePreview = document.getElementById('image-preview');
-
-  window.addEventListener('DOMContentLoaded', () => {
-    const imagePreview = document.getElementById('image-preview');
-    //ページが読み込まれた時に、src属性にデフォルトの画像を設定して表示する
-    imagePreview.src = '<%= asset_path("default_avatar.png") %>';
-  });
-
-  //画像をクリックしたらファイルアップロードボタンのクリック操作を実行する
-  imagePreview.addEventListener('click', () => {
-    fileInput.click();
-  });
-
-  fileInput.addEventListener('change', (e) => {
-    const file = e.target.files[0];
-
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        imagePreview.src = e.target.result;
-      };
-      reader.readAsDataURL(file);
-    } else {
-      imagePreview.src = 'app/assets/images/default_avatar.png';
-    }
-  });
-});
-</script>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,4 @@
-<div class="flash-message-container">
+<div class="form-flash-message-container">
   <%= render 'shared/flash_message' %>
 </div>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,4 @@
-<div class="form-flash-message-container">
+<div class="flash-message-container">
   <%= render 'shared/flash_message' %>
 </div>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,9 +1,14 @@
+<%= render 'shared/modal' %>
+<%= render 'shared/delete_image' %>
+
 <div class="flash-message-container">
   <%= render 'shared/flash_message' %>
 </div>
 
-<%= render 'shared/modal' %>
-<%= render 'shared/delete_image' %>
+<div class="form-breadcrumbs">
+  <%= render_breadcrumbs separator: ' > ' %>
+</div>
+
 <div class="form-container">
   <h1 class="title">ユーザー新規登録</h1>
   <%= form_with model: @user, method: :post do |f| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,11 +7,7 @@ Rails.application.routes.draw do
 
   resources :users, except: [:index]
 
-  resources :events do
-    member do
-      delete 'delete_image'
-    end
-  end
+  resources :events
 
   resources :categories do
     resources :events, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,11 @@ Rails.application.routes.draw do
 
   resources :users, except: [:index]
 
-  resources :events
+  resources :events do
+    member do
+      delete 'delete_image'
+    end
+  end
 
   resources :categories do
     resources :events, only: [:index]

--- a/db/migrate/20240515215925_add_column_delete_image_flag.rb
+++ b/db/migrate/20240515215925_add_column_delete_image_flag.rb
@@ -1,0 +1,5 @@
+class AddColumnDeleteImageFlag < ActiveRecord::Migration[7.1]
+  def change
+    add_column :events, :delete_image, :boolean, :default => false
+  end
+end

--- a/db/migrate/20240515215925_add_column_delete_image_to_events.rb
+++ b/db/migrate/20240515215925_add_column_delete_image_to_events.rb
@@ -1,4 +1,4 @@
-class AddColumnDeleteImageFlag < ActiveRecord::Migration[7.1]
+class AddColumnDeleteImageToEvents < ActiveRecord::Migration[7.1]
   def change
     add_column :events, :delete_image, :boolean, :default => false
   end

--- a/db/migrate/20240518105618_add_column_delete_image_to_users.rb
+++ b/db/migrate/20240518105618_add_column_delete_image_to_users.rb
@@ -1,0 +1,5 @@
+class AddColumnDeleteImageToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :delete_image, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_26_215313) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_15_215925) do
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_26_215313) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "delete_image", default: false
     t.index ["category_id"], name: "index_events_on_category_id"
     t.index ["user_id"], name: "index_events_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_15_215925) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_18_105618) do
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -70,6 +70,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_15_215925) do
     t.string "phone_number", null: false
     t.string "self_introduction"
     t.datetime "discard_at"
+    t.boolean "delete_image", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,7 @@ require 'date'
 
 #ユーザー
 10.times do |n|
-  user = User.create!(name: "test#{n+1}", email: "test#{n+1}@example.com", password: "password#{n+1}", phone_number: "031234000#{n+1}", self_introduction: "テストユーザー#{n+1}です")
+  user = User.create!(name: "test#{n+1}", email: "test#{n+1}@example.com", password: "password#{n+1}", phone_number: "031234000#{n+1}", self_introduction: "テストユーザー#{n+1}です", delete_image: false)
   user.image.attach(io: File.open(Rails.root.join('app', 'assets', 'images', 'default_avatar.png')), filename: 'default_avatar.png')
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -88,7 +88,8 @@ last_day = Date.parse("2024-12-31")
     name: "イベント#{n+1}",
     event_description: "イベント#{n+1}の説明です。",
     event_day: rand(start_day..last_day),
-    public_status: 1
+    public_status: 1,
+    delete_image: false
   )
 
   begin


### PR DESCRIPTION
## チケットへのリンク
- なし（任意のタスク）

## やったこと
- [breadcrumbs_on_rails](https://github.com/weppos/breadcrumbs_on_rails)によるパンくずリストの実装
- CSSの修正（レスポンシブ対応含む）

## やらないこと
- なし

## できるようになること（ユーザ目線）
- パンくずリストからページの現在位置が把握できる
- 一覧ページなどで戻るボタンをクリックしなくても、パンくずリストから簡単に直前のページに戻れる

## できなくなること（ユーザ目線）
- なし

## デザイン
- パンくずリスト（例）
<img width="1440" alt="スクリーンショット 2024-05-20 5 58 44" src="https://github.com/kyohei-p/event-management-app/assets/107188352/08f05c52-060b-4972-9f4d-f13bfe63d069">


## レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- 類似するパンくずリストのgemとして[gretel](https://github.com/lassebunk/gretel)があります。 [breadcrumbs_on_rails](https://github.com/weppos/breadcrumbs_on_rails)のほうが個人的により簡単に実装できたので、そちらを採用しました。
- パンくずリストのTOPのホームアイコンですが、fontawasomeを使用しています。
- TOPの文字列の中にiタグを埋め込もうとした時に [Railsデフォルトの仕様によりhtmlエスケープされ、iタグがそのまま表示されます。](https://qiita.com/kimascript/items/3af2cb07fd9cdb879192)それを回避するためにhtml_safeを使用し、iタグをHTMLタグとして解釈するようにしています。（ユーザーが入力するテキストデータなどではないので、[XSS攻撃](https://www.shadan-kun.com/waf_websecurity/xss/)を受けるリスクは低いと判断しています）
- マージは、前にPRした[イベント編集](https://github.com/kyohei-p/event-management-app/pull/8)・[ユーザー登録の画像削除](https://github.com/kyohei-p/event-management-app/pull/9)をマージ後に行います。
