### PR TITLE
イベント詳細ページ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@
 @import url(shared/header.css);
 @import url(shared/footer.css);
 @import url(shared/modal.css);
+@import url(shared/reset.css);
 @import url(login.css);
 @import url(events/index.css);
 @import url(events/pagination.css);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@
 @import url(login.css);
 @import url(events/index.css);
 @import url(events/pagination.css);
+@import url(events/show.css);
 @import url(events/manage_index.css);
 
 /* フラッシュメッセージ */

--- a/app/assets/stylesheets/events/index.css
+++ b/app/assets/stylesheets/events/index.css
@@ -233,7 +233,7 @@
   grid-column: 2 / 3;
   grid-row: 1 / 2;
   margin-top: 10px;
-  margin-left: 50px;
+  margin-left: 30px;
 }
 
 .edit-button:hover {
@@ -245,7 +245,7 @@
   grid-column: 2 / 3;
   grid-row: 2 / 3;
   margin-bottom: 10px;
-  margin-left: 47px;
+  margin-left: 27px;
 }
 
 .trash-icon:hover {

--- a/app/assets/stylesheets/events/index.css
+++ b/app/assets/stylesheets/events/index.css
@@ -128,7 +128,6 @@
   display: flex;
   width: 500px;
   border: 0.5px solid var(--gray);
-  cursor: pointer;
 }
 
 .card:hover {
@@ -171,6 +170,22 @@
   margin-left: 30px;
 }
 
+/* 詳細ページへの遷移 */
+.transition-from-image:hover {
+  cursor: pointer;
+  opacity: 0.7;
+}
+
+.transition-from-name {
+  color: var(--black);
+  text-decoration: none;
+}
+
+.transition-from-name:hover {
+  color: var(--theme_color);
+  cursor: pointer;
+}
+
 /* カテゴリ */
 .category-label {
   grid-row: 1 / 2;
@@ -195,6 +210,7 @@
 .category-label:hover {
   background-color: var(--theme_hover_color);
   opacity: 0.7;
+  cursor: pointer;
 }
 
 /* 開催日 */
@@ -224,6 +240,7 @@
   color: var(--theme_hover_color);
   opacity: 0.7;
   text-decoration: underline;
+  cursor: pointer;
 }
 
 .card__button {
@@ -240,6 +257,7 @@
 
 .edit-button:hover {
   opacity: 0.7;
+  cursor: pointer;
 }
 
 .trash-icon {
@@ -251,6 +269,7 @@
 
 .trash-icon:hover {
   opacity: 0.7;
+  cursor: pointer;
 }
 
 /* 削除アイコン */

--- a/app/assets/stylesheets/events/index.css
+++ b/app/assets/stylesheets/events/index.css
@@ -79,27 +79,9 @@
 }
 
 /* ログインへの遷移ボタン */
-.transition-login-button {
-  display: inline-block;
-}
-
-.button-text {
-  display: flex;
+.transition-button-container {
+  display: grid;
   justify-content: center;
-  align-items: center;
-  width: 200px;
-  height: 40px;
-  border: none;
-  border-radius: 4px;
-  background-color: var(--theme_color);
-  color: #ffffff;
-  font-size: 18px;
-}
-
-.button-text:hover {
-  border: 1px solid var(--theme_color);
-  color: var(--theme_color);
-  background-color: var(--white);
 }
 
 /* イベント一覧 */
@@ -200,7 +182,7 @@
   text-wrap: wrap;
   border: none;
   border-radius: 20px;
-  background-color: var(--theme_color);
+  background: var(--theme_gradient_color);
   color: var(--white);
   font-size: 1rem;
   text-align: center;
@@ -208,7 +190,6 @@
 }
 
 .category-label:hover {
-  background-color: var(--theme_hover_color);
   opacity: 0.7;
   cursor: pointer;
 }
@@ -364,7 +345,7 @@
     text-wrap: wrap;
     border: none;
     border-radius: 20px;
-    background-color: var(--theme_color);
+    background: var(--theme_gradient_color);
     color: var(--white);
     font-size: 1rem;
     text-align: center;
@@ -372,7 +353,7 @@
   }
 
   .category-label:hover {
-    background-color: var(--theme_hover_color);
+    opacity: 0.8;
   }
 
   .card__items {
@@ -410,7 +391,6 @@
     margin-top: 0;
     margin-left: 25px;
     margin-right: 0;
-    /* padding-top: 0; */
   }
 
   .trash-icon:hover {
@@ -452,7 +432,6 @@
     margin-top: 0;
     margin-left: 25px;
     margin-right: 0;
-    /* padding-top: 0; */
   }
 
   .trash-icon:hover {

--- a/app/assets/stylesheets/events/show.css
+++ b/app/assets/stylesheets/events/show.css
@@ -87,6 +87,91 @@ table td{
   opacity: 0.7;
 }
 
-.comment-area {
+.comment-container {
   margin: 100px;
+  border-radius: 3px;
+  margin-bottom: 20px;
+  background-color: #fff;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12);
 }
+
+.comment-title {
+  background-color: var(--light-gray);
+}
+
+.comment-inner {
+  padding: 10px;
+}
+
+.comment-form {
+  display: flex;
+  align-items: center;
+}
+
+.comment-field {
+  width: 100%;
+}
+
+#comment-submit-button {
+  width: 100px;
+  margin-left: 10px;
+  border: none;
+  border-radius: 4px;
+  background: var(--theme_gradient_color);
+  color: #ffffff;
+  font-size: 18px;
+}
+
+#comment-list {
+  display: flex;
+  flex-direction: column;
+  margin-top: 10px;
+  border-bottom: 1px solid var(--light-gray);
+}
+
+#comment-list:last-child {
+  border-bottom: none;
+}
+
+
+.comment-subtitle {
+  padding-bottom: 10px;
+  margin: 0;
+  margin-bottom: 0;
+  border-bottom: 1px solid var(--light-gray);
+}
+
+.comment-user-info {
+  display: flex;
+  align-items: baseline;
+  padding-left: 10px;
+}
+
+.comment-username {
+  margin-left: 5px;
+}
+
+.username {
+  margin-bottom: 0;
+}
+
+.user-thumbnail-container {
+  margin-left: 10px;
+}
+
+.created-comment {
+  margin-left: 70px;
+  padding: 5px;
+  overflow-wrap: break-word;
+}
+
+.no-comment {
+  font-size: 0.8rem;
+}
+
+
+
+
+
+
+

--- a/app/assets/stylesheets/events/show.css
+++ b/app/assets/stylesheets/events/show.css
@@ -17,7 +17,6 @@
 }
 
 .event-summary__image {
-  /* width: 60%; */
   border: 1px solid var(--light-gray);
 }
 
@@ -34,7 +33,6 @@ caption {
 
 table{
   width: 60%;
-  /* margin-right: 30px; */
 }
 
 /*左上の角を丸くする */
@@ -98,7 +96,7 @@ table td{
 
 .comment-container {
   width: 80%;
-  margin: 100px;
+  margin: 50px 100px;
   border-radius: 3px;
   margin-bottom: 20px;
   background-color: #fff;
@@ -120,6 +118,8 @@ table td{
 
 .comment-field {
   width: 100%;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 #comment-submit-button {
@@ -132,23 +132,21 @@ table td{
   font-size: 18px;
 }
 
-#comment-list {
+.comment-list {
   display: flex;
   flex-direction: column;
   margin-top: 10px;
-  border-bottom: 1px solid var(--light-gray);
+  padding-top: 10px;
+  border-top: 1px solid var(--light-gray);
+  opacity: 1;
 }
 
-#comment-list:last-child {
+.comment-list:last-child {
   border-bottom: none;
 }
 
-
 .comment-subtitle {
-  padding-bottom: 10px;
   margin: 0;
-  margin-bottom: 0;
-  border-bottom: 1px solid var(--light-gray);
 }
 
 .comment-user-info {
@@ -177,6 +175,51 @@ table td{
 
 .no-comment {
   font-size: 0.8rem;
+}
+
+/* もっとみるボタン */
+
+.more-list-btn-container {
+  position: relative;
+  margin-bottom: 10px;
+  z-index: 10;
+  border-top: 1px solid var(--light-gray);
+  text-align: center;
+}
+
+.comment-list.is-hidden {
+  opacity: 0;
+  height: 0;
+  margin: 0;
+}
+
+.more-list-btn {
+  margin-top: 20px;
+  cursor: pointer;
+}
+
+.more-list-btn:hover {
+  opacity: 0.8;
+}
+
+.more-list-btn-container.is-btn-hidden,
+.more-list-btn.is-btn-hidden{
+  display:none;
+  border: none;
+}
+
+.more-list-btn {
+  display: inline-block;
+  background-color: #333;
+  color:#fff;
+  border: 1px solid #333;
+  border-radius: 3px;
+  cursor: pointer;
+  outline: none;
+  padding: 0;
+  height: 32px;
+  line-height: 32px;
+  width: 120px;
 }
 
 

--- a/app/assets/stylesheets/events/show.css
+++ b/app/assets/stylesheets/events/show.css
@@ -19,6 +19,10 @@
   margin: 100px;
 }
 
+caption {
+  color: var(--black) !important;
+}
+
 table{
   width: 100%;
   margin-right: 30px;
@@ -83,10 +87,6 @@ table td{
   opacity: 0.7;
 }
 
-.profile-image {
-  width: 40px;
-  height: 40px;
-  margin-right: 10px;
-  border: 0.5px solid var(--gray);
-  border-radius: 50%;
+.comment-area {
+  margin: 100px;
 }

--- a/app/assets/stylesheets/events/show.css
+++ b/app/assets/stylesheets/events/show.css
@@ -8,15 +8,16 @@
 .event-summary {
   display: flex;
   justify-content: center;
-  /* margin-left: 140px; */
 }
 
 .event-summary__container {
   display: flex;
   flex-direction: column;
+  margin-left: 26%;
 }
 
 .event-summary__image {
+  width: 60%;
   border: 1px solid var(--light-gray);
 }
 
@@ -221,10 +222,3 @@ table td{
   line-height: 32px;
   width: 120px;
 }
-
-
-
-
-
-
-

--- a/app/assets/stylesheets/events/show.css
+++ b/app/assets/stylesheets/events/show.css
@@ -6,7 +6,9 @@
 
 /* イベントの概要 */
 .event-summary {
-  margin-left: 140px;
+  display: flex;
+  justify-content: center;
+  /* margin-left: 140px; */
 }
 
 .event-summary__container {
@@ -15,7 +17,7 @@
 }
 
 .event-summary__image {
-  width: 60%;
+  /* width: 60%; */
   border: 1px solid var(--light-gray);
 }
 
@@ -31,8 +33,8 @@ caption {
 }
 
 table{
-  width: 90%;
-  margin-right: 30px;
+  width: 60%;
+  /* margin-right: 30px; */
 }
 
 /*左上の角を丸くする */
@@ -77,7 +79,7 @@ table td{
   max-height: max-content;
   background: #f7f6f5;
   color: var(--black);
-  padding: 10px;
+  padding: 10px 20px;
   text-align: left;
 }
 

--- a/app/assets/stylesheets/events/show.css
+++ b/app/assets/stylesheets/events/show.css
@@ -82,3 +82,11 @@ table td{
   text-decoration: underline;
   opacity: 0.7;
 }
+
+.profile-image {
+  width: 40px;
+  height: 40px;
+  margin-right: 10px;
+  border: 0.5px solid var(--gray);
+  border-radius: 50%;
+}

--- a/app/assets/stylesheets/events/show.css
+++ b/app/assets/stylesheets/events/show.css
@@ -1,0 +1,84 @@
+.event-detail-container {
+  display: flex;
+  flex-direction: column;
+  margin: 100px;
+}
+
+/* イベントの概要 */
+.event-summary {
+  margin: 50px 100px;
+}
+
+.event-summary__image {
+  width: 100%;
+  border: 1px solid var(--light-gray);
+}
+
+/* イベントの詳細情報 */
+.event-info {
+  margin: 100px;
+}
+
+table{
+  width: 100%;
+  margin-right: 30px;
+}
+
+/*左上の角を丸くする */
+table tr:first-child > th:first-child {
+  border-radius: 4px 0 0 0;
+}
+
+/* 左下の角を丸くする */
+table tr:last-child > th:first-child {
+  border-radius: 0 0 0 4px;
+}
+
+/* 右上の角を丸くする */
+table tr:first-child > td:last-child {
+  border-radius: 0 4px 0 0;
+}
+
+/* 右下の角を丸くする */
+table tr:last-child > td:last-child {
+  border-radius: 0 0 4px 0;
+}
+
+table tr {
+  height: 80px;
+  background: var(--white);
+}
+
+table th td {
+  border-bottom: 1px solid var(--light-gray);
+  text-wrap: wrap;
+}
+
+table th {
+  width: 30%;
+  background: linear-gradient(40deg, var(--theme_color) 0%, #fce043 80%);
+  color: var(--white);
+  text-align: center;
+}
+
+table td{
+  height: 100px;
+  max-height: max-content;
+  background: #f7f6f5;
+  color: var(--black);
+  padding: 10px;
+  text-align: left;
+}
+
+.event-info__eventday,
+.event-info__category {
+  color: var(--theme_color);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.event-info__eventday:hover,
+.event-info__category:hover {
+  text-decoration: underline;
+  opacity: 0.7;
+}

--- a/app/assets/stylesheets/events/show.css
+++ b/app/assets/stylesheets/events/show.css
@@ -6,16 +6,23 @@
 
 /* イベントの概要 */
 .event-summary {
-  margin: 50px 100px;
+  margin-left: 140px;
+}
+
+.event-summary__container {
+  display: flex;
+  flex-direction: column;
 }
 
 .event-summary__image {
-  width: 100%;
+  width: 60%;
   border: 1px solid var(--light-gray);
 }
 
 /* イベントの詳細情報 */
 .event-info {
+  display: flex;
+  justify-content: center;
   margin: 100px;
 }
 
@@ -24,7 +31,7 @@ caption {
 }
 
 table{
-  width: 100%;
+  width: 90%;
   margin-right: 30px;
 }
 
@@ -88,6 +95,7 @@ table td{
 }
 
 .comment-container {
+  width: 80%;
   margin: 100px;
   border-radius: 3px;
   margin-bottom: 20px;

--- a/app/assets/stylesheets/login.css
+++ b/app/assets/stylesheets/login.css
@@ -6,7 +6,7 @@
   width: 200px;
   height: 40px;
   color: var(--theme_color);
-  background-color: #ffffff;
+  background: var(--white);
   border: 1px solid var(--theme_color);
   border-radius: 4px;
   font-size: 18px;
@@ -14,7 +14,7 @@
 }
 
 .signup-link-button:hover {
-  color: #ffffff;
-  background-color: var(--theme_color);
+  background: var(--theme_color);
+  color: var(--white);
 }
 

--- a/app/assets/stylesheets/shared/colors.css
+++ b/app/assets/stylesheets/shared/colors.css
@@ -12,4 +12,7 @@
   --brown: #D9D1B4;
   --theme_color: #FF9900;
   --theme_hover_color: #FF9966;
+  --theme_gradient_color: linear-gradient(40deg, var(--theme_color), #fce043);
+  --header_gradient_color: linear-gradient(30deg, #ffc100, #f6cd4a 70%, #fce043 100%);
+  --footer_gradient_color: linear-gradient(-30deg, #ffc100, #f6cd4a 70%, #fce043 100%);
 }

--- a/app/assets/stylesheets/shared/common.css
+++ b/app/assets/stylesheets/shared/common.css
@@ -253,3 +253,12 @@ input[type='file']:hover {
     margin: 100px 0 0 20px;
   }
 }
+
+/* プロフィールアイコン */
+.small-profile-image {
+  width: 40px;
+  height: 40px;
+  margin-right: 10px;
+  border: 0.5px solid var(--gray);
+  border-radius: 50%;
+}

--- a/app/assets/stylesheets/shared/common.css
+++ b/app/assets/stylesheets/shared/common.css
@@ -66,16 +66,13 @@ select {
   height: 40px;
   border: none;
   border-radius: 4px;
-  background-color: var(--theme_color);
+  background: var(--theme_gradient_color);
   color: #ffffff;
   font-size: 18px;
 }
 
 .submit-button:hover {
-  border: 1px solid var(--theme_color);
-  color: var(--theme_color);
-  background-color: #ffffff;
-
+  background: var(--theme_color);
 }
 
 /* 戻るボタン */

--- a/app/assets/stylesheets/shared/common.css
+++ b/app/assets/stylesheets/shared/common.css
@@ -255,7 +255,7 @@ input[type='file']:hover {
 }
 
 /* プロフィールアイコン */
-.small-profile-image {
+.user-thumbnail {
   width: 40px;
   height: 40px;
   margin-right: 10px;

--- a/app/assets/stylesheets/shared/footer.css
+++ b/app/assets/stylesheets/shared/footer.css
@@ -2,7 +2,7 @@ footer {
   position: fixed;
   bottom: 0;
   width: 100%;
-  background-color: var(--theme_color);
+  background: linear-gradient(-30deg, #ffc100, #f6cd4a 70%, #fce043 100%);
   z-index: 999;
 }
 

--- a/app/assets/stylesheets/shared/footer.css
+++ b/app/assets/stylesheets/shared/footer.css
@@ -2,7 +2,7 @@ footer {
   position: fixed;
   bottom: 0;
   width: 100%;
-  background: linear-gradient(-30deg, #ffc100, #f6cd4a 70%, #fce043 100%);
+  background: var(--footer_gradient_color);
   z-index: 999;
 }
 

--- a/app/assets/stylesheets/shared/header.css
+++ b/app/assets/stylesheets/shared/header.css
@@ -4,7 +4,7 @@ nav.navbar {
   top: 0%;
   width: 100%;
   z-index: 999;
-  background: linear-gradient(30deg, #ffc100, #f6cd4a 70%, #fce043 100%);
+  background: var(--header_gradient_color);
 }
 
 .navbar > .container {

--- a/app/assets/stylesheets/shared/header.css
+++ b/app/assets/stylesheets/shared/header.css
@@ -4,7 +4,7 @@ nav.navbar {
   top: 0%;
   width: 100%;
   z-index: 999;
-  background-color: var(--theme_color);
+  background: linear-gradient(30deg, #ffc100, #f6cd4a 70%, #fce043 100%);
 }
 
 .navbar > .container {

--- a/app/assets/stylesheets/shared/reset.css
+++ b/app/assets/stylesheets/shared/reset.css
@@ -1,0 +1,3 @@
+button:not(:disabled), [type="button"]:not(:disabled), [type="reset"]:not(:disabled), [type="submit"]:not(:disabled) {
+  cursor: pointer;
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,23 @@
+class CommentsController < ApplicationController
+  def create
+    @comment = Comment.new(comment_params)
+    @comment.event = Event.find(params[:event_id])
+    @comment.user = current_user
+
+    if @comment.save
+      render json: { status: 'success', message_type: 'notice', message: "コメントを投稿しました", comment_data: @comment }, status: 200
+    else
+      render json: { status: 'error', message_type: 'alert', message: "コメントを投稿できませんでした", errors: @comment.errors.full_messages }, status: 422
+    end
+  end
+
+  def new
+    @comment = Comment.new
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:content, :event_id, :user_id)
+  end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,11 +1,19 @@
 class CommentsController < ApplicationController
+  skip_before_action :require_login, only: [:create]
+
   def create
     @comment = Comment.new(comment_params)
     @comment.event = Event.find(params[:event_id])
-    @comment.user = current_user
+    if current_user
+      @comment.user = current_user
+      image_url = Rails.application.routes.url_helpers.rails_blob_path(current_user.image, only_path: true)
+    else
+      @comment.user = nil
+      image_url = nil
+    end
 
     if @comment.save
-      render json: { status: 'success', message_type: 'notice', message: "コメントを投稿しました", comment_data: @comment }, status: 200
+      render json: { status: 'success', message_type: 'notice', message: "コメントを投稿しました", comment_data: @comment, user_data: @comment.user, image_url: image_url }, status: 200
     else
       render json: { status: 'error', message_type: 'alert', message: "コメントを投稿できませんでした", errors: @comment.errors.full_messages }, status: 422
     end
@@ -18,6 +26,6 @@ class CommentsController < ApplicationController
   private
 
   def comment_params
-    params.require(:comment).permit(:content, :event_id, :user_id)
+    params.require(:comment).permit(:content, :event_id)
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,5 @@
 class EventsController < ApplicationController
-  skip_before_action :require_login, only: [:index]
+  skip_before_action :require_login, only: [:index, :show]
   before_action :require_login, only: [:create, :new, :manage_events]
   before_action :set_event, only: [:edit, :update, :show, :destroy]
   before_action :event_create_breadcrumb, only: [:new, :create]

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -76,6 +76,7 @@ class EventsController < ApplicationController
     set_event
     add_breadcrumb 'イベント一覧', events_path
     add_breadcrumb 'イベント詳細', event_path(id: params[:id])
+    @comments = Comment.where(event_id: params[:id]).order(created_at: "DESC").limit(10)
   end
 
   def destroy

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -73,6 +73,9 @@ class EventsController < ApplicationController
   end
 
   def show
+    set_event
+    add_breadcrumb 'イベント一覧', events_path
+    add_breadcrumb 'イベント詳細', event_path(id: params[:id])
   end
 
   def destroy

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,6 +3,7 @@ import "@hotwired/turbo-rails"
 import "controllers"
 import "./preview"
 import "./flash"
+import "./more_list_btn"
 
 $(function() {
   $('.flash-message').fadeOut(5000);

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,6 +2,7 @@ import "bootstrap"
 import "@hotwired/turbo-rails"
 import "controllers"
 import "./preview"
+import "./flash"
 
 $(function() {
   $('.flash-message').fadeOut(5000);

--- a/app/javascript/flash.js
+++ b/app/javascript/flash.js
@@ -1,0 +1,19 @@
+//フラッシュメッセージを非同期で表示/非表示にする関数
+function flashMessage(data) {
+  const div = document.createElement('div');
+  div.className = 'flash-message';
+  div.textContent = data.message;
+
+  const flashContainer = document.querySelector('.flash-message-container');
+  flashContainer.appendChild(div);
+  div.classList.add(data.message_type);
+
+  flashContainer.style.position = 'fixed';
+  flashContainer.style.top = '50%';
+  flashContainer.style.left = '50%';
+  flashContainer.style.opacity = 0.9;
+  flashContainer.style.zIndex = 99;
+  $(div).fadeOut(5000);
+};
+
+window.flashMessage = flashMessage;

--- a/app/javascript/more_list_btn.js
+++ b/app/javascript/more_list_btn.js
@@ -1,0 +1,37 @@
+// もっとみるボタン
+document.addEventListener('DOMContentLoaded', () => {
+  // 表示するリストの数
+  const moreNum = 5;
+
+  const moreListBtn = document.querySelector('.more-list-btn-container');
+  if(!moreListBtn) { return false; }
+  moreListBtn.classList.remove('is-btn-hidden');
+
+
+  const commentList = Array.from(document.querySelectorAll('.comment-list'));
+
+  // 表示する数以降のリストを隠す
+    if(commentList.length > moreNum) {
+      commentList.slice(moreNum).forEach(list => {
+      list.classList.add('is-hidden');
+    })
+  }
+
+  // 「もっとみる」ボタンをクリックしたら、全てのリストを表示
+  moreListBtn.addEventListener('click', () => {
+    const hiddenList = document.querySelectorAll('.comment-list.is-hidden');
+    hiddenList.forEach(list => {
+      list.classList.remove('is-hidden');
+    });
+
+    moreListBtn.classList.add('is-btn-hidden');
+    if(hiddenList.length == 0) {
+      moreListBtn.style.display = 'none';
+    }
+  });
+
+  // 全てのリストの数が、表示する数以下だった場合に「もっとみる」ボタンを非表示
+  if(commentList.length <= moreNum) {
+    moreListBtn.classList.add('is-btn-hidden');
+  };
+});

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :event
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, optional: true
   belongs_to :event
+
+  validates :content, presence: true, length: { maximum: 255 }
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,6 +4,7 @@ class Event < ApplicationRecord
 
   belongs_to :user
   belongs_to :category
+  has_many :comments, dependent: :destroy
 
   has_one_attached :image
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -24,4 +24,7 @@ class Event < ApplicationRecord
     errors.add(:category_id, "カテゴリーを選択してください。") if category_id.nil?
   end
 
+  def owned_by?(user)
+    self.user_id == user.id
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,9 @@ class User < ApplicationRecord
 
   has_one_attached :image
 
+  has_many :events
+  has_many :comments
+
   validates :name, presence: true, length: { maximum: 100 }
 
   before_save { self.email = email.downcase }

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -23,7 +23,7 @@
     </div>
     <div class="transition-button-container">
       <a href="/login" class="submit-button text-decoration-none mb-2 p-2" data-turbo="false">
-        <span class="button-text">ログインする</span>
+        <span class="submit-button">ログインする</span>
       </a>
     </div>
   </section>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -43,13 +43,19 @@
       <div class="card shadow p-3 mb-5 bg-white rounded">
         <div class="card__inner">
           <% if event.image.attached? %>
-            <%= image_tag event.image, class:"card__image" %>
+            <%= link_to event_path(event), class: "transition-from-image", data: { turbo:false } do %>
+              <%= image_tag event.image, class:"card__image" %>
+            <% end %>
           <% else %>
-            <%= image_tag 'events/no_image.png', class:"card__image" %>
+            <%= link_to event_path(event), class: "transition-from-image", data: { turbo:false } do %>
+              <%= image_tag 'events/no_image.png', class:"card__image" %>
+            <% end %>
           <% end %>
           <div class="card__textbox">
             <div class="card__title">
-              <%= event.name.truncate(33) %>
+              <%= link_to event_path(event), class: "transition-from-name", data: { turbo:false } do %>
+                <%= event.name.truncate(33) %>
+              <% end %>
             </div>
             <div class="card__items">
               <%= link_to category_events_path(category_id: event.category.id), class: "category-label", data: { turbo:false } do %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -22,7 +22,7 @@
       </ol>
     </div>
     <div class="transition-button-container">
-      <a href="/login" class="transition-login-button text-decoration-none" data-turbo="false">
+      <a href="/login" class="submit-button text-decoration-none mb-2 p-2" data-turbo="false">
         <span class="button-text">ログインする</span>
       </a>
     </div>

--- a/app/views/events/manage_events.html.erb
+++ b/app/views/events/manage_events.html.erb
@@ -19,13 +19,19 @@
         <div class="card shadow p-3 mb-5 bg-white rounded" id="event-card" data-event-id="<%= event.id %>" data-event-name="<%= event.name %>" data-message="を削除しますか？">
           <div class="card__inner">
             <% if event.image.attached? %>
-              <%= image_tag event.image, class:"card__image" %>
+               <%= link_to event_path(event), class: "transition-from-image", data: { turbo:false } do %>
+                <%= image_tag event.image, class:"card__image" %>
+              <% end %>
             <% else %>
-              <%= image_tag 'events/no_image.png', class:"card__image" %>
+              <%= link_to event_path(event), class: "transition-from-image", data: { turbo:false } do %>
+                <%= image_tag 'events/no_image.png', class:"card__image" %>
+              <% end %>
             <% end %>
             <div class="card__textbox">
               <div class="card__title">
-                <%= event.name.truncate(33) %>
+                <%= link_to event_path(event), class: "transition-from-name", data: { turbo:false } do %>
+                  <%= event.name.truncate(33) %>
+                <% end %>
               </div>
               <div class="card__items">
                 <%= link_to manage_category_events_path(category_id: event.category.id), class: "category-label", data: { turbo:false } do %>

--- a/app/views/events/manage_events.html.erb
+++ b/app/views/events/manage_events.html.erb
@@ -116,32 +116,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if(response.ok) {
           eventCard.remove();
-          flashMessage(data);
+           window.flashMessage(data);
         } else {
-          flashMessage(data);
+           window.flashMessage(data);
         }
       } catch(e) {
         console.error( e.name, e.message );
       }
     })
   });
-
-  //フラッシュメッセージを非同期で表示/非表示にする関数
-  function flashMessage(data) {
-    const div = document.createElement('div');
-    div.className = 'flash-message';
-    div.textContent = data.message;
-
-    const flashContainer = document.querySelector('.flash-message-container');
-    flashContainer.appendChild(div);
-    div.classList.add(data.message_type);
-
-    flashContainer.style.position = 'fixed';
-    flashContainer.style.top = '50%';
-    flashContainer.style.left = '50%';
-    flashContainer.style.opacity = 0.9;
-    flashContainer.style.zIndex = 99;
-    $(div).fadeOut(5000);
-  };
 });
 </script>

--- a/app/views/events/manage_events.html.erb
+++ b/app/views/events/manage_events.html.erb
@@ -61,7 +61,7 @@
       <div class="transition-event-create">
         <h2 class="transition-guidance">イベントの作成はこちらのボタンから</h2><br />
         <a href="/events/new" class="transition-event-create-button text-decoration-none" data-turbo="false">
-          <span class="button-text">イベント作成</span>
+          <span class="submit-button">イベント作成</span>
         </a>
       </div>
     </div>

--- a/app/views/events/manage_events.html.erb
+++ b/app/views/events/manage_events.html.erb
@@ -116,9 +116,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if(response.ok) {
           eventCard.remove();
-          displayFlashMessage(data);
+          flashMessage(data);
         } else {
-          displayFlashMessage(data);
+          flashMessage(data);
         }
       } catch(e) {
         console.error( e.name, e.message );
@@ -127,7 +127,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   //フラッシュメッセージを非同期で表示/非表示にする関数
-  function displayFlashMessage(data) {
+  function flashMessage(data) {
     const div = document.createElement('div');
     div.className = 'flash-message';
     div.textContent = data.message;

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,54 @@
+<div class="event-detail-container">
+  <div class="breadcrumbs">
+    <%= render_breadcrumbs separator: ' > ' %>
+  </div>
+
+  <div class="title-container">
+    <h1 class="title">イベント詳細</h1>
+  </div>
+
+  <section class="event-summary">
+    <div class="event-summary__name mt-4 mb-3">
+      <h2><%= @event.name %></h2>
+    </div>
+    <%= image_tag @event.image, class: "event-summary__image mt-3 mb-4" %>
+  </section>
+
+  <section class="event-info mt-4 mb-4">
+    <table>
+      <caption align="top" class="fw-bold mb-2">イベントの詳細情報</caption>
+      <tbody>
+        <tr>
+          <th scope="row">主催者</th>
+          <td><span class="fw-bold fs-4"><%= @event.user.name %></span>さん</td>
+        </tr>
+        <tr>
+          <th scope="row">イベントの説明</th>
+          <td><%= @event.event_description %></td>
+        </tr>
+        <tr>
+          <th scope="row">開催日</th>
+          <td>
+            <%= link_to date_events_path(event_day: @event.event_day), class:"event-info__eventday", data: { turbo:false } do %>
+              <span class="event-info__eventday"><%= @event.event_day.strftime("%-m月%-d日") %></span>
+            <% end %>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">カテゴリ</th>
+          <td>
+            <%= link_to category_events_path(category_id: @event.category.id), class: "event-info__category", data: { turbo:false } do %>
+              <%= @event.category.name %>
+            <% end %>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="event-backbutton">
+    <div class="back-button-container mt-3 mb-4">
+      <%= link_to 'イベント一覧に戻る', events_path, class:"back-button", data: { turbo: false } %>
+    </div>
+  </section>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -12,10 +12,10 @@
   </div>
 
   <section class="event-summary">
-    <div class="event-summary__name mt-4 mb-3">
-      <h2><%= @event.name %></h2>
+    <div class="event-summary__container">
+      <h2 class="event-summary__name mt-4 mb-2"><%= @event.name %></h2>
+      <%= image_tag @event.image, class: "event-summary__image mt-2 mb-4" %>
     </div>
-    <%= image_tag @event.image, class: "event-summary__image mt-3 mb-4" %>
   </section>
 
   <section class="event-info mt-4 mb-4">
@@ -57,7 +57,7 @@
   </section>
 
   <section class="comment-container">
-    <h3 class="comment-title fs-5 p-1">フィード</h3>
+    <h3 class="comment-title fs-5 p-2">フィード</h3>
     <div class="comment-inner p-2">
       <form action="/comments" method="post" class="comment-form mb-2" data-event-id="<%= @event.id %>">
         <input type="text" name="comment[content]" class="comment-field mt-2 mb-2 pt-2 pb-2" placeholder="コメント">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -151,7 +151,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  //バリデーションのエラーメッセージ関数
+  //バリデーションのエラーメッセージ
   function validationErrorMessage(data) {
     const errorMessages = document.getElementById('error-messages');
     errorMessages.innerHTML = '';
@@ -188,39 +188,5 @@ document.addEventListener('DOMContentLoaded', () => {
     const commentList = document.querySelector('.comment-area');
     commentList.insertAdjacentHTML('afterbegin', newComment);
   };
-
-  // もっとみるボタン
-  // 表示するリストの数
-  const moreNum = 5;
-
-  const moreListBtn = document.querySelector('.more-list-btn-container');
-  moreListBtn.classList.remove('is-btn-hidden');
-
-  const commentList = Array.from(document.querySelectorAll('.comment-list'));
-
-  // 表示する数以降のリストを隠す
-    if(commentList.length > moreNum) {
-      commentList.slice(moreNum).forEach(list => {
-      list.classList.add('is-hidden');
-    })
-  }
-
-  // 「もっとみる」ボタンをクリックしたら、全てのリストを表示
-  moreListBtn.addEventListener('click', () => {
-    const hiddenList = document.querySelectorAll('.comment-list.is-hidden');
-    hiddenList.forEach(list => {
-      list.classList.remove('is-hidden');
-    });
-
-    moreListBtn.classList.add('is-btn-hidden');
-    if(hiddenList.length == 0) {
-      moreListBtn.style.display = 'none';
-    }
-  });
-
-  // 全てのリストの数が、表示する数以下だった場合に「もっとみる」ボタンを非表示
-  if(commentList.length <= moreNum) {
-    moreListBtn.classList.add('is-btn-hidden');
-  }
 });
 </script>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -67,11 +67,11 @@
       </form>
       <div id="error-messages"></div>
       <p class="comment-subtitle fs-6 fw-bold">投稿されたコメント</p>
-      <div id="comment-area" class="mt-1 pt-1">
+      <div class="comment-area" class="mt-1 pt-1">
         <% if @comments.present? %>
           <% @comments.each do |comment| %>
-            <div id="comment-list">
-              <div class="comment-user-info mt-2">
+            <div class="comment-list">
+              <div class="comment-user-info mt-3">
                 <div class="user-thumbnail-container">
                   <% if comment.user %>
                     <% if comment.user.image.attached? %>
@@ -97,6 +97,9 @@
         <% else %>
           <p id="no-comment">コメントはまだありません</p>
         <% end %>
+        <div class="more-list-btn-container">
+          <button type="button" class="more-list-btn pointer-cursor">もっと見る</button>
+        </div>
       </div>
     </div>
   </section>
@@ -169,8 +172,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const newComment = `
-      <div id="comment-list">
-        <div class="comment-user-info">
+      <div class="comment-list">
+        <div class="comment-user-info pt-3">
           <div class="user-thumbnail-container">
             ${data.image_url ? `<img src="${data.image_url}" class="user-thumbnail" />` : `<img src="<%= asset_path('default_avatar.png') %>" class="user-thumbnail" />` }
           </div>
@@ -178,12 +181,46 @@ document.addEventListener('DOMContentLoaded', () => {
             ${data.user_data ? `<p class="username">${data.user_data.name}さん</p>` : `<p class="username">ゲストさん</p>`}
           </div>
         </div>
-        <p class="created-comment"><span><i class="fa fa-comment-o" aria-hidden="true"></i>&nbsp;${data.comment_data.content}</span></p>
+        <p class="created-comment"><span><i class="fa fa-comment-o" aria-hidden="true"></i>&nbsp;&nbsp;${data.comment_data.content}</span></p>
       </div>
     `
 
-    const commentList = document.getElementById('comment-area');
+    const commentList = document.querySelector('.comment-area');
     commentList.insertAdjacentHTML('afterbegin', newComment);
   };
+
+  // もっとみるボタン
+  // 表示するリストの数
+  const moreNum = 5;
+
+  const moreListBtn = document.querySelector('.more-list-btn-container');
+  moreListBtn.classList.remove('is-btn-hidden');
+
+  const commentList = Array.from(document.querySelectorAll('.comment-list'));
+
+  // 表示する数以降のリストを隠す
+    if(commentList.length > moreNum) {
+      commentList.slice(moreNum).forEach(list => {
+      list.classList.add('is-hidden');
+    })
+  }
+
+  // 「もっとみる」ボタンをクリックしたら、全てのリストを表示
+  moreListBtn.addEventListener('click', () => {
+    const hiddenList = document.querySelectorAll('.comment-list.is-hidden');
+    hiddenList.forEach(list => {
+      list.classList.remove('is-hidden');
+    });
+
+    moreListBtn.classList.add('is-btn-hidden');
+    if(hiddenList.length == 0) {
+      moreListBtn.style.display = 'none';
+    }
+  });
+
+  // 全てのリストの数が、表示する数以下だった場合に「もっとみる」ボタンを非表示
+  if(commentList.length <= moreNum) {
+    moreListBtn.classList.add('is-btn-hidden');
+  }
 });
 </script>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,4 +1,8 @@
 <div class="event-detail-container">
+  <div class="flash-message-container">
+    <%= render 'shared/flash_message' %>
+  </div>
+
   <div class="breadcrumbs">
     <%= render_breadcrumbs separator: ' > ' %>
   </div>
@@ -51,4 +55,122 @@
       <%= link_to 'イベント一覧に戻る', events_path, class:"back-button", data: { turbo: false } %>
     </div>
   </section>
+
+  <section class="comment-area">
+    <h3>フィード</h3>
+    <form action="/comments" method="post" class="comment-form" data-event-id="<%= @event.id %>">
+      <input type="text" name="comment[content]" class="comment-field mt-2 mb-2 pt-2 pb-2" placeholder="コメント">
+      <button type="submit" id="comment-submit-button" class="submit-button">
+        送信
+      </button>
+      <div id="error-messages"></div>
+    </form>
+    <% if @comments.present? %>
+      <% @comments.each do |comment| %>
+        <div class="comment-user-info">
+          <div class="user-image">
+            <% if comment.user.image.attached? %>
+              <%= image_tag comment.user.image, class:"header-profile-image" %>
+            <% else %>
+              <%= image_tag 'default_avatar.png', class:"header-profile-image" %>
+            <% end%>
+          </div>
+          <div class="comment-username">
+            <% if comment.user %>
+              <p class="username"><%= comment.user.name.truncate(13) %>さん</p>
+            <% else %>
+              <p class="username">ゲストさん</p>
+            <% end %>
+          </div>
+        </div>
+        <div class="comment-area">
+          <p class="created-comment">コメント：<span><%= comment.content %></span></p>
+        </div>
+      <% end %>
+    <% else %>
+      <p>コメントはまだありません</p>
+    <% end %>
+  </section>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const submitButton = document.getElementById("comment-submit-button");
+  const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  submitButton.addEventListener('click', async(event) => {
+    event.preventDefault();
+
+    commentForm = submitButton.closest(".comment-form");
+    let eventId = commentForm.getAttribute("data-event-id");
+    const contentInput = commentForm.querySelector('input[name="comment[content]"]');
+    const formData = new FormData(commentForm);
+    formData.append('content', contentInput);
+
+    const errorMessages = document.getElementById("error-messages");
+
+    try {
+      const url = `<%= ENV['DEVELOPMENT_URL'] %>/events/${eventId}/comments`;
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': csrfToken
+        },
+        body: formData
+      })
+
+      const data = await response.json();
+      console.log(data)
+
+      if(response.ok) {
+        contentInput.value = '';
+        errorMessages.innerHTML = '';
+        flashMessage(data);
+      } else {
+        if (data.errors) {
+          validationErrorMessage(data);
+        } else {
+          flashMessage(data);
+        }
+      }
+    } catch(e) {
+      console.error(e.name, e.message);
+    }
+  });
+
+  // フラッシュメッセージを非同期で表示/非表示にする関数
+  function flashMessage(data) {
+    const div = document.createElement('div');
+    div.className = 'flash-message';
+    div.textContent = data.message;
+
+    const flashContainer = document.querySelector('.flash-message-container');
+    flashContainer.innerHTML = '';
+    flashContainer.appendChild(div);
+    div.classList.add(data.message_type);
+
+    flashContainer.style.position = 'fixed';
+    flashContainer.style.top = '50%';
+    flashContainer.style.left = '50%';
+    flashContainer.style.opacity = 0.9;
+    flashContainer.style.zIndex = 99;
+    $(div).fadeOut(5000);
+  };
+
+  //バリデーションのエラーメッセージ関数
+  function validationErrorMessage(data) {
+    const errorMessages = document.getElementById('error-messages');
+    errorMessages.innerHTML = '';
+    data.errors.forEach(error => {
+      const errorMessage = document.createElement('div');
+      errorMessage.className = 'error-message';
+      errorMessage.textContent = error.replace('Content', '');
+      console.log(errorMessage.textContent)
+      errorMessages.appendChild(errorMessage);
+      errorMessages.style.marginBottom = '20px';
+    });
+  };
+
+});
+
+</script>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -135,37 +135,18 @@ document.addEventListener('DOMContentLoaded', () => {
         contentInput.value = '';
         errorMessages.innerHTML = '';
         newCommentHTML(data);
-        flashMessage(data);
+        window.flashMessage(data);
       } else {
         if (data.errors) {
           validationErrorMessage(data);
         } else {
-          flashMessage(data);
+          window.flashMessage(data);
         }
       }
     } catch(e) {
       console.error(e.name, e.message);
     }
   });
-
-  // フラッシュメッセージを非同期で表示/非表示にする関数
-  function flashMessage(data) {
-    const div = document.createElement('div');
-    div.className = 'flash-message';
-    div.textContent = data.message;
-
-    const flashContainer = document.querySelector('.flash-message-container');
-    flashContainer.innerHTML = '';
-    flashContainer.appendChild(div);
-    div.classList.add(data.message_type);
-
-    flashContainer.style.position = 'fixed';
-    flashContainer.style.top = '50%';
-    flashContainer.style.left = '50%';
-    flashContainer.style.opacity = 0.9;
-    flashContainer.style.zIndex = 99;
-    $(div).fadeOut(5000);
-  };
 
   //バリデーションのエラーメッセージ関数
   function validationErrorMessage(data) {

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -20,7 +20,7 @@
 
   <section class="event-info mt-4 mb-4">
     <table>
-      <caption align="top" class="fw-bold mb-2">イベントの詳細情報</caption>
+      <caption align="top" class="fw-bold fs-3 mb-2">イベントの詳細情報</caption>
       <tbody>
         <tr>
           <th scope="row">主催者</th>
@@ -57,7 +57,7 @@
   </section>
 
   <section class="comment-area">
-    <h3>フィード</h3>
+    <h3 class="fs-3">フィード</h3>
     <form action="/comments" method="post" class="comment-form" data-event-id="<%= @event.id %>">
       <input type="text" name="comment[content]" class="comment-field mt-2 mb-2 pt-2 pb-2" placeholder="コメント">
       <button type="submit" id="comment-submit-button" class="submit-button">
@@ -65,31 +65,39 @@
       </button>
       <div id="error-messages"></div>
     </form>
-    <% if @comments.present? %>
-      <% @comments.each do |comment| %>
-        <div class="comment-user-info">
-          <div class="user-image">
-            <% if comment.user.image.attached? %>
-              <%= image_tag comment.user.image, class:"header-profile-image" %>
-            <% else %>
-              <%= image_tag 'default_avatar.png', class:"header-profile-image" %>
-            <% end%>
+    <div id="comment-container">
+      <% if @comments.present? %>
+        <% @comments.each do |comment| %>
+          <div id="comment-list">
+            <div class="comment-user-info">
+              <div class="user-image">
+                <% if comment.user %>
+                  <% if comment.user.image.attached? %>
+                    <%= image_tag comment.user.image, class:"small-profile-image" %>
+                  <% else %>
+                    <%= image_tag 'default_avatar.png', class:"small-profile-image" %>
+                  <% end%>
+                <% else %>
+                  <%= image_tag 'default_avatar.png', class:"small-profile-image" %>
+                <% end %>
+              </div>
+              <div class="comment-username">
+                <% if comment.user %>
+                  <p class="username"><%= comment.user.name.truncate(13) %>さん</p>
+                <% else %>
+                  <p class="username">ゲストさん</p>
+                <% end %>
+              </div>
+            </div>
+            <div class="comment-content">
+              <p class="created-comment">コメント：<span><%= comment.content %></span></p>
+            </div>
           </div>
-          <div class="comment-username">
-            <% if comment.user %>
-              <p class="username"><%= comment.user.name.truncate(13) %>さん</p>
-            <% else %>
-              <p class="username">ゲストさん</p>
-            <% end %>
-          </div>
-        </div>
-        <div class="comment-area">
-          <p class="created-comment">コメント：<span><%= comment.content %></span></p>
-        </div>
+        <% end %>
+      <% else %>
+        <p id="no-comment">コメントはまだありません</p>
       <% end %>
-    <% else %>
-      <p>コメントはまだありません</p>
-    <% end %>
+    </div>
   </section>
 </div>
 
@@ -125,6 +133,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if(response.ok) {
         contentInput.value = '';
         errorMessages.innerHTML = '';
+        newCommentHTML(data);
         flashMessage(data);
       } else {
         if (data.errors) {
@@ -165,12 +174,36 @@ document.addEventListener('DOMContentLoaded', () => {
       const errorMessage = document.createElement('div');
       errorMessage.className = 'error-message';
       errorMessage.textContent = error.replace('Content', '');
-      console.log(errorMessage.textContent)
       errorMessages.appendChild(errorMessage);
       errorMessages.style.marginBottom = '20px';
     });
   };
 
-});
+  //送信されたコメントを追加する関数
+  function newCommentHTML(data) {
+    const noComment = document.getElementById("no-comment");
+    if(noComment) {
+      noComment.remove();
+    }
 
+    const newComment = `
+      <div class="comment-list">
+        <div class="comment-user-info">
+          <div class="user-image">
+            ${data.image_url ? `<img src="${data.image_url}" class="small-profile-image" />` : `<img src="<%= asset_path('default_avatar.png') %>" class="small-profile-image" />` }
+          </div>
+          <div class="comment-username">
+            ${data.user_data ? `<p class="username">${data.user_data.name}さん</p>` : `<p class="username">ゲストさん</p>`}
+          </div>
+        </div>
+        <div class="comment-content">
+          <p class="created-comment">コメント：<span>${data.comment_data.content}</span></p>
+        </div>
+      </div>
+    `
+
+    const commentList = document.getElementById('comment-container');
+    commentList.insertAdjacentHTML('afterbegin', newComment);
+  };
+});
 </script>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -56,47 +56,48 @@
     </div>
   </section>
 
-  <section class="comment-area">
-    <h3 class="fs-3">フィード</h3>
-    <form action="/comments" method="post" class="comment-form" data-event-id="<%= @event.id %>">
-      <input type="text" name="comment[content]" class="comment-field mt-2 mb-2 pt-2 pb-2" placeholder="コメント">
-      <button type="submit" id="comment-submit-button" class="submit-button">
-        送信
-      </button>
+  <section class="comment-container">
+    <h3 class="comment-title fs-5 p-1">フィード</h3>
+    <div class="comment-inner p-2">
+      <form action="/comments" method="post" class="comment-form mb-2" data-event-id="<%= @event.id %>">
+        <input type="text" name="comment[content]" class="comment-field mt-2 mb-2 pt-2 pb-2" placeholder="コメント">
+        <button type="submit" id="comment-submit-button" class="submit-button">
+          送信
+        </button>
+      </form>
       <div id="error-messages"></div>
-    </form>
-    <div id="comment-container">
-      <% if @comments.present? %>
-        <% @comments.each do |comment| %>
-          <div id="comment-list">
-            <div class="comment-user-info">
-              <div class="user-image">
-                <% if comment.user %>
-                  <% if comment.user.image.attached? %>
-                    <%= image_tag comment.user.image, class:"small-profile-image" %>
+      <p class="comment-subtitle fs-6 fw-bold">投稿されたコメント</p>
+      <div id="comment-area" class="mt-1 pt-1">
+        <% if @comments.present? %>
+          <% @comments.each do |comment| %>
+            <div id="comment-list">
+              <div class="comment-user-info mt-2">
+                <div class="user-thumbnail-container">
+                  <% if comment.user %>
+                    <% if comment.user.image.attached? %>
+                      <%= image_tag comment.user.image, class:"user-thumbnail" %>
+                    <% else %>
+                      <%= image_tag 'default_avatar.png', class:"user-thumbnail" %>
+                    <% end%>
                   <% else %>
-                    <%= image_tag 'default_avatar.png', class:"small-profile-image" %>
-                  <% end%>
-                <% else %>
-                  <%= image_tag 'default_avatar.png', class:"small-profile-image" %>
-                <% end %>
+                    <%= image_tag 'default_avatar.png', class:"user-thumbnail" %>
+                  <% end %>
+                </div>
+                <div class="comment-username">
+                  <% if comment.user %>
+                    <p class="username"><%= comment.user.name.truncate(13) %>さん</p>
+                  <% else %>
+                    <p class="username">ゲストさん</p>
+                  <% end %>
+                </div>
               </div>
-              <div class="comment-username">
-                <% if comment.user %>
-                  <p class="username"><%= comment.user.name.truncate(13) %>さん</p>
-                <% else %>
-                  <p class="username">ゲストさん</p>
-                <% end %>
-              </div>
+              <p class="created-comment"><span><i class="fa fa-comment-o" aria-hidden="true"></i>&nbsp;&nbsp;<%= comment.content %></span></p>
             </div>
-            <div class="comment-content">
-              <p class="created-comment">コメント：<span><%= comment.content %></span></p>
-            </div>
-          </div>
+          <% end %>
+        <% else %>
+          <p id="no-comment">コメントはまだありません</p>
         <% end %>
-      <% else %>
-        <p id="no-comment">コメントはまだありません</p>
-      <% end %>
+      </div>
     </div>
   </section>
 </div>
@@ -187,22 +188,20 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const newComment = `
-      <div class="comment-list">
+      <div id="comment-list">
         <div class="comment-user-info">
-          <div class="user-image">
-            ${data.image_url ? `<img src="${data.image_url}" class="small-profile-image" />` : `<img src="<%= asset_path('default_avatar.png') %>" class="small-profile-image" />` }
+          <div class="user-thumbnail-container">
+            ${data.image_url ? `<img src="${data.image_url}" class="user-thumbnail" />` : `<img src="<%= asset_path('default_avatar.png') %>" class="user-thumbnail" />` }
           </div>
           <div class="comment-username">
             ${data.user_data ? `<p class="username">${data.user_data.name}さん</p>` : `<p class="username">ゲストさん</p>`}
           </div>
         </div>
-        <div class="comment-content">
-          <p class="created-comment">コメント：<span>${data.comment_data.content}</span></p>
-        </div>
+        <p class="created-comment"><span><i class="fa fa-comment-o" aria-hidden="true"></i>&nbsp;${data.comment_data.content}</span></p>
       </div>
     `
 
-    const commentList = document.getElementById('comment-container');
+    const commentList = document.getElementById('comment-area');
     commentList.insertAdjacentHTML('afterbegin', newComment);
   };
 });

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
         user: ユーザー
         category: カテゴリー
         event: イベント
+        comment: コメント
     attributes:
       user:
         name: "名前"
@@ -18,6 +19,8 @@ ja:
         event_description: "イベントの説明文"
         event_day: "開催日"
         public_status: "公開状態"
+      comment:
+        conetent: "コメント内容"
     errors:
       models:
         user:
@@ -51,6 +54,11 @@ ja:
               blank: "開催日を選択してください。"
             public_status:
               blank: "公開状態を選択してください。"
+        comment:
+          attributes:
+            content:
+              blank: "コメントを入力してください。"
+              too_long: "コメントは255文字以内で入力してください。"
       messages:
         required: "%{attribute}は必須項目です。"
         record_invalid: "バリデーションに失敗しました: %{errors}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   resources :users, except: [:index]
   resources :events do
-    resources :comments, only: [:create, :new, :destroy]
+    resources :comments, only: [:index, :create, :new, :destroy]
   end
 
   resources :categories do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
   get 'logout' => 'sessions#destroy', as: :logout
 
   resources :users, except: [:index]
-  resources :events
+  resources :events do
+    resources :comments, only: [:create, :new, :destroy]
+  end
 
   resources :categories do
     resources :events, only: [:index]

--- a/db/migrate/20240526043305_create_comments.rb
+++ b/db/migrate/20240526043305_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :comments do |t|
+      t.string :content
+      t.references :event, foreign_key: true
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_20_113136) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_26_043305) do
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -45,6 +45,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_20_113136) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "comments", charset: "utf8mb4", force: :cascade do |t|
+    t.string "content"
+    t.bigint "event_id"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_comments_on_event_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
   create_table "events", charset: "utf8mb4", force: :cascade do |t|
     t.string "name"
     t.string "event_description"
@@ -77,6 +87,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_20_113136) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "events"
+  add_foreign_key "comments", "users"
   add_foreign_key "events", "categories"
   add_foreign_key "events", "users"
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## チケットへのリンク
- [ イベント詳細](https://prum.backlog.com/view/PRUM_ACADEMY-2325)
- [コメント機能](https://prum.backlog.com/view/PRUM_ACADEMY-2326)

## やったこと
- イベント詳細情報の取得・表示
- イベント一覧に戻るボタン実装
- Commentモデル・マイグレーションファイルの追加
- コメントの非同期送信機能（バリデーションの実装あり）
- 送信したコメントとユーザーの表示（非同期）
- コメント送信後のフラッシュメッセージ表示

## やらないこと
- もっとみるボタンの実装（別タスクで任意の実装）
- イベントを作成したユーザーが詳細ページ内でコメントを削除する（要検討）
- コメントを送信したユーザーが詳細ページ内でコメントを編集する（要検討）
- イベント管理ページからの遷移の場合、ルート（`manage/events/:id`）を分ける&イベント管理に戻るボタン（要検討）

## できるようになること（ユーザ目線）
- イベントの詳細情報が見れる
- イベント一覧に戻れる
- コメントを送信できる
- 他ユーザーが投稿したコメントが見れる

## できなくなること（ユーザ目線）
- 投稿されたコメントの編集・削除

## デザイン
- イベント名〜画像
<img width="1440" alt="スクリーンショット 2024-05-30 7 04 55" src="https://github.com/kyohei-p/event-management-app/assets/107188352/550a62ef-bb41-49c5-8d58-85e367a2b7b6">. 

- 詳細情報
<img width="1440" alt="スクリーンショット 2024-05-30 7 05 05" src="https://github.com/kyohei-p/event-management-app/assets/107188352/6963c7af-1ca4-4153-8dcc-ad317258aa2f">. 

- コメント
<img width="1440" alt="スクリーンショット 2024-05-30 7 06 09" src="https://github.com/kyohei-p/event-management-app/assets/107188352/230439c3-3a17-4183-b94c-89c81de92a7d">

- 直近の10件まで表示
<img width="742" alt="スクリーンショット 2024-05-30 7 12 10" src="https://github.com/kyohei-p/event-management-app/assets/107188352/d3f9a0ed-1ecf-4f6e-bc7c-83cd12522d8e">


- 動作確認（コメント投稿時）
https://github.com/kyohei-p/event-management-app/assets/107188352/77ecae86-6654-4ae5-8871-5cb7208f0dbd


## レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- コメント機能の実装とデザインは、[connpassのイベント詳細ページ](https://datascienceteam.connpass.com/event/312289/)を参考にしました。