### PR TITLE
イベント編集（作成）ページのフォーム変更

### DIFF
--- a/app/assets/stylesheets/events/index.css
+++ b/app/assets/stylesheets/events/index.css
@@ -143,6 +143,7 @@
   font-size: 2rem;
   font-weight: bold;
   text-align: left;
+  overflow-wrap: anywhere;
 }
 
 .card__items {
@@ -227,13 +228,14 @@
 .card__button {
   display: grid;
   grid-row: 1 / 3;
+  text-align: center;
+  margin-left: 30px;
 }
 
 .edit-button {
   grid-column: 2 / 3;
   grid-row: 1 / 2;
   margin-top: 10px;
-  margin-left: 30px;
 }
 
 .edit-button:hover {
@@ -245,7 +247,6 @@
   grid-column: 2 / 3;
   grid-row: 2 / 3;
   margin-bottom: 10px;
-  margin-left: 27px;
 }
 
 .trash-icon:hover {

--- a/app/assets/stylesheets/shared/common.css
+++ b/app/assets/stylesheets/shared/common.css
@@ -68,7 +68,8 @@ select {
 
 .submit-button {
   width: 200px;
-  height: 40px;
+  height: auto;
+  padding: 10px;
   border: none;
   border-radius: 4px;
   background: var(--theme_gradient_color);

--- a/app/assets/stylesheets/shared/common.css
+++ b/app/assets/stylesheets/shared/common.css
@@ -41,6 +41,11 @@ select {
   padding: 5px;
 }
 
+.form-select {
+  border: 1px solid gray !important;
+  border-radius: 0.2rem !important;
+}
+
 /* カレンダー */
 .form-control-sm {
   border: 1px solid light-dark(rgb(118, 118, 118), rgb(133, 133, 133));

--- a/app/assets/stylesheets/users/mypage.css
+++ b/app/assets/stylesheets/users/mypage.css
@@ -1,0 +1,69 @@
+.mypage-container {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  margin: 100px auto;
+}
+
+.mypage-title {
+  text-align: center;
+}
+
+.user-info-table {
+  margin: 50px auto;
+}
+
+.mypage-btns {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+}
+
+.mypage-actions {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+
+
+/* 退会ボタン */
+.unsubscribe-button.btn-primary {
+  --bs-btn-bg: none !important;
+  --bs-btn-border-color: none !important;
+  --bs-btn-hover-bg: none !important;
+  --bs-btn-hover-border-color: none !important;
+  --bs-btn-active-bg: none !important;
+  --bs-btn-active-border-color: none !important;
+  --bs-btn-disabled-bg: none !important;
+  --bs-btn-disabled-border-color: none !important;
+  padding: 0 !important;
+}
+.unsubscribe-button.btn-primary {
+  width: 100px;
+  height: 40px;
+  margin-left: 10px;
+  --bs-btn-color: var(--white) !important;
+  --bs-btn-bg: var(--red) !important;
+  --bs-btn-border-color: var(--red) !important;
+  --bs-btn-active-bg: var(--red) !important;
+  --bs-btn-active-border-color: var(--red) !important;
+  --bs-btn-disabled-bg: var(--red) !important;
+  --bs-btn-disabled-border-color: var(--red) !important;
+  --bs-btn-hover-bg: var(--red) !important;
+  --bs-btn-hover-border-color: var(--red) !important;
+}
+
+.unsubscribe-button.btn.btn-primary:hover {
+  --bs-btn-color: var(--white) !important;
+  --bs-btn-bg: var(--red) !important;
+  --bs-btn-border-color: var(--red) !important;
+  opacity: 0.8 !important;
+}
+
+.unsubscribe-button.btn.outline:hover {
+  color: var(--white);
+  background-color: var(--red);
+  border: 1px solid var(--red);
+  opacity: 0.8;
+}

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,2 +1,10 @@
 class CategoriesController < ApplicationController
+  def index
+    @categories = Category.all
+    if @categories.present?
+      render json: { status: 'success', message: "全てのカテゴリー情報を取得しました", categories: @categories }, status: 200
+    else
+      render json: { status: 'error', message: "全てのカテゴリー情報を取得できませんでした" }, status: 500
+    end
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,7 @@
 class EventsController < ApplicationController
   skip_before_action :require_login, only: [:index, :show]
   before_action :require_login, only: [:create, :new, :manage_events]
-  before_action :set_event, only: [:edit, :update, :show, :destroy]
+  before_action :set_event, only: [:edit, :update, :show, :destroy, :event_category]
   before_action :event_create_breadcrumb, only: [:new, :create]
   before_action :event_update_breadcrumb, only: [:edit, :update]
 
@@ -49,6 +49,7 @@ class EventsController < ApplicationController
   end
 
   def edit
+    @category = @event.category
   end
 
   def update
@@ -101,6 +102,15 @@ class EventsController < ApplicationController
     else
       @manage_events = Event.where(user_id: current_user).order(updated_at: "DESC").page(params[:page])
       add_breadcrumb 'イベント管理', manage_events_path
+    end
+  end
+
+  def event_category
+    @category = @event.category
+    if @category.present?
+      render json: { status: 'success', message: "イベントのカテゴリーを取得しました", category: @category }, status: 200
+    else
+      render json: { status: 'error', message: "イベントのカテゴリーを取得できませんでした" }, status: 500
     end
   end
 

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -32,7 +32,11 @@
       </div>
       <div class="mt-4 mb-4">
         <%= f.label "カテゴリー", class:"label-tag fw-bold" %><br />
-        <%= f.collection_select :category_id, Category.all, :id, :name, include_blank: "選択してください", class:"form-control" %>
+        <select name="event[category_id]" id="category-select" class="form-select h-auto">
+          <option class="default-value" value=""><%= @category ? @category.name : "選択してください" %></option>
+          <option value="">選択してください</option>
+        </select>
+        <div id="selected-option"></div>
         <% if @event.errors[:category_id].any? %>
           <div class="error-message mt-1">
             <%= safe_join(@event.errors[:category_id]) %>
@@ -89,3 +93,50 @@
     <% end %>
   </div>
 <% end %>
+
+<script>
+document.addEventListener('DOMContentLoaded', async() => {
+  const categorySelect = document.querySelector('#category-select');
+
+  categorySelect.addEventListener('click', async() => {
+    // クリックされた時にサーバーから取得・表示したカテゴリのoptionを削除
+    const defaultValue = document.querySelector('.default-value');
+    if(!defaultValue) { return false; }
+    defaultValue.remove();
+
+    try {
+      const url = `<%= ENV['DEVELOPMENT_URL'] %>/categories`;
+
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        },
+      });
+
+      const data = await response.json();
+      console.log(data);
+
+      if(response.ok) {
+        // 取得したカテゴリーのoptionを追加する
+        data.categories.forEach(category => {
+        let newOption = new Option(category.name, category.id);
+        newOption.classList.add('category-option')
+        categorySelect.append(newOption)
+        });
+      } else {
+        console.error("カテゴリーを取得できませんでした")
+      }
+    } catch(e) {
+      console.error(e.class, e.message);
+    }
+    // 選択されたカテゴリでoptionの表示内容を変更する
+    const selectedOption = document.getElementById('selected-option');
+    selectedOption.addEventListener('change', () => {
+      const categoryData = categorySelect.options[categorySelect.selectedIndex].text;
+      selectedOption.textContent = `${categoryData}`;
+    })
+  });
+});
+</script>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -33,7 +33,7 @@
       <div class="mt-4 mb-4">
         <%= f.label "カテゴリー", class:"label-tag fw-bold" %><br />
         <select name="event[category_id]" id="category-select" class="form-select h-auto">
-          <option class="default-value" value=""><%= @category ? @category.name : "選択してください" %></option>
+          <option class="default-value" value="<%= @category ? @category.id : "" %>"><%= @category ? @category.name : "選択してください" %></option>
           <option value="">選択してください</option>
         </select>
         <div id="selected-option"></div>
@@ -98,13 +98,7 @@
 document.addEventListener('DOMContentLoaded', async() => {
   const categorySelect = document.querySelector('#category-select');
 
-  categorySelect.addEventListener('click', async() => {
-    // クリックされた時にサーバーから取得・表示したカテゴリのoptionを削除
-    const defaultValue = document.querySelector('.default-value');
-    if(!defaultValue) { return false; }
-    defaultValue.remove();
-
-    try {
+      try {
       const url = `<%= ENV['DEVELOPMENT_URL'] %>/categories`;
 
       const response = await fetch(url, {
@@ -131,6 +125,13 @@ document.addEventListener('DOMContentLoaded', async() => {
     } catch(e) {
       console.error(e.class, e.message);
     }
+
+  categorySelect.addEventListener('click', async() => {
+    // クリックされた時にサーバーから取得・表示したカテゴリのoptionを削除
+    const defaultValue = document.querySelector('.default-value');
+    if(!defaultValue) { return false; }
+    defaultValue.remove();
+
     // 選択されたカテゴリでoptionの表示内容を変更する
     const selectedOption = document.getElementById('selected-option');
     selectedOption.addEventListener('change', () => {

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -23,7 +23,7 @@
     </div>
     <div class="transition-button-container">
       <a href="/login" class="submit-button text-decoration-none mb-2 p-2" data-turbo="false">
-        <span class="submit-button">ログインする</span>
+        ログインする
       </a>
     </div>
   </section>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -23,7 +23,7 @@
       </div>
       <div class="mt-4 mb-4">
         <%= f.label "イベントの説明", class:"label-tag fw-bold" %><br />
-        <%= f.text_area :event_description, placeholder:"イベントの説明文を入力", rows: 5, class: "text-area w-100 p-2" %>
+        <textarea name="event[event_description]" placeholder="イベントの説明文を入力" rows="5" class="text-area w-100 p-2"></textarea>
         <% if @event.errors[:event_description].any? %>
           <div class="error-message mt-1">
             <%= safe_join(@event.errors[:event_description]) %>


### PR DESCRIPTION
## チケットへのリンク
- なし

## やったこと
- `f.text_area`をhtmlのtextareaタグに変更
- `f.collection_select`をhtmlのselectタグとoptionタグに変更
- カテゴリ名を非同期でサーバーから取得し、セレクトボックスの選択肢として表示
- イベント一覧ページ他のcss修正

## やらないこと
- なし

## できるようになること（ユーザ目線）
- 変わらない

## できなくなること（ユーザ目線）
- なし

## デザイン
<img width="1440" alt="スクリーンショット 2024-06-02 9 53 27" src="https://github.com/kyohei-p/event-management-app/assets/107188352/7e32b32c-8e14-4712-9885-7ced995c8ced">
<img width="1440" alt="スクリーンショット 2024-06-02 9 53 42" src="https://github.com/kyohei-p/event-management-app/assets/107188352/328c7fdd-746a-423f-8be3-4881cd82da48">

## レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- 必須タスクでないため、ページの一部のみ変更