### PR TITLE
ユーザー情報編集

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,8 @@
 class UsersController < ApplicationController
   skip_before_action :require_login, only: [:new, :create]
   before_action :regist_breadcrumb, only: [:new, :create]
-  before_action :set_user, only: [:show, :edit]
+  before_action :update_breadcrumb, only: [:edit, :update]
+  before_action :set_user, only: [:show, :edit, :update]
 
   def create
     ApplicationRecord.transaction do
@@ -32,10 +33,32 @@ class UsersController < ApplicationController
   def edit
   end
 
+  def update
+    ApplicationRecord.transaction do
+      @user.update(user_params)
+
+      if params[:user][:delete_image] == 'true'
+        @user.image.purge
+      end
+
+      if @user.save
+        redirect_to(user_path(current_user), notice: 'ユーザー情報を更新しました')
+      else
+        flash.now[:alert] = 'ユーザー情報の更新に失敗しました'
+        render action: 'edit'
+      end
+    end
+  end
+
   private
 
   def regist_breadcrumb
     add_breadcrumb 'ユーザー新規登録', new_user_path
+  end
+
+  def update_breadcrumb
+    add_breadcrumb 'マイページ', user_path(current_user)
+    add_breadcrumb 'ユーザー情報編集', edit_user_path
   end
 
   def set_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -66,6 +66,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :phone_number, :self_introduction, :image, :delete_image)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :phone_number, :self_introduction, :image, :delete_image)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,8 +17,11 @@ class User < ApplicationRecord
   VALID_PASSWORD_MESSAGE_HANKAKU = "パスワードは半角英数字で入力してください"
   VALID_PASSWORD_MESSAGE_MINLENGTH = "パスワードは8文字以上で入力してください"
   VALID_PASSWORD_MESSAGE_MAXLENGTH = "パスワードは16文字以内で入力してください"
-  validates :password, presence: true, if: -> { new_record? || changes[:crypted_password] }
+
+  validates :password, confirmation: true, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validate :validate_password
+
+  validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
   VALID_PHONE_NUMBER_REGEX = /\A\d{10,11}\z/
   VALID_PHONE_NUMBER_MESSAGE_HAIFUN = "電話番号はハイフン無しで入力してください"
@@ -46,5 +49,4 @@ class User < ApplicationRecord
       errors.add(:phone_number, VALID_PHONE_NUMBER_MESSAGE_LENGTH) unless phone_number =~ VALID_PHONE_NUMBER_REGEX
     end
   end
-
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -50,10 +50,19 @@
     </div>
     <div class="mt-4 mb-4">
       <%= f.label "パスワード", class:"label-tag fw-bold" %><br />
-      <%= f.password_field :password, placeholder:"変更時のみパスワードを入力してください", class:"text-field p-2", value: @user.password %>
+      <%= f.password_field :password, placeholder:"変更時のみ新しいパスワードを入力してください", class:"text-field p-2", autocomplete: "off" %>
       <% if @user.errors[:password].any? %>
         <div class="error-message mt-1">
           <%= raw(@user.errors[:password].join("<br>")) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="mt-4 mb-4">
+      <%= f.label "確認用パスワード", class:"label-tag fw-bold" %><br />
+      <%= f.password_field :password_confirmation, placeholder:"新しいパスワードをもう一度入力してください", class:"text-field p-2", autocomplete: "off" %>
+      <% if @user.errors[:password_confirmation].any? %>
+        <div class="error-message mt-1">
+          <%= raw(@user.errors[:password_confirmation].join("<br>")) %>
         </div>
       <% end %>
     </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,84 @@
+<%= render 'shared/modal' %>
+<%= render 'shared/delete_image' %>
+
+<div class="flash-message-container">
+  <%= render 'shared/flash_message' %>
+</div>
+
+<div class="form-breadcrumbs">
+  <%= render_breadcrumbs separator: ' > ' %>
+</div>
+
+<div class="form-container">
+  <h1 class="title">ユーザー情報編集</h1>
+  <%= form_with model: @user, method: :patch do |f| %>
+    <div class="mt-4 mb-4">
+      <%= f.label "名前", class:"label-tag fw-bold" %><br />
+      <%= f.text_field :name, placeholder:"例）山田 太郎", class:"name-field p-2" %>
+      <% if @user.errors[:name].any? %>
+        <div class="error-message mt-1">
+          <%= raw(@user.errors[:name].join("<br>")) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="mt-4 mb-4">
+      <%= f.label "自己紹介", class:"label-tag fw-bold" %><br />
+      <%= f.text_area :self_introduction, placeholder:"自己紹介文を入力", rows: 5, class: "text-area w-100 p-2" %>
+      <% if @user.errors[:self_introduction].any? %>
+        <div class="error-message mt-1">
+          <%= raw(@user.errors[:self_introduction].join("<br>")) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="mt-4 mb-4">
+      <%= f.label "メールアドレス", class:"label-tag fw-bold" %><br />
+      <%= f.text_field :email, placeholder:"例）taro.yamada@example.com", class:"text-field p-2" %>
+      <% if @user.errors[:email].any? %>
+        <div class="error-message mt-1">
+          <%= raw(@user.errors[:email].join("<br>")) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="mt-4 mb-4">
+      <%= f.label "電話番号", class:"label-tag fw-bold" %><br />
+      <%= f.text_field :phone_number, placeholder:"例）0120224568", class:"text-field p-2" %>
+      <% if @user.errors[:phone_number].any? %>
+        <div class="error-message mt-1">
+          <%= raw(@user.errors[:phone_number].join("<br>")) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="mt-4 mb-4">
+      <%= f.label "パスワード", class:"label-tag fw-bold" %><br />
+      <%= f.password_field :password, placeholder:"変更時のみパスワードを入力してください", class:"text-field p-2", value: @user.password %>
+      <% if @user.errors[:password].any? %>
+        <div class="error-message mt-1">
+          <%= raw(@user.errors[:password].join("<br>")) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="image-field mt-4 mb-5" data-turbo="false">
+      <%= f.label "プロフィール画像", class: "label-tag fw-bold" %><br />
+      <div class="speech-bubble-area">
+        <p class="speech-bubble">画像をクリックして、ファイルを選択できます。</p>
+        <% if @user.image.attached? %>
+          <img id="image-preview" src="<%= url_for(@user.image) %>", class="mt-2 mb-2" /><br />
+        <% else %>
+          <img id="image-preview" src="<%= asset_path("default_avatar.png") %>", class="mt-2 mb-2" /><br />
+        <% end %>      </div>
+    </div>
+    <div class="image-button-container">
+      <%= f.file_field :image, class: "upload-button", id: "image-upload" %>
+      <button type="button" id="image-delete-button" class="btn outline btn-primary" data-bs-toggle="modal" data-bs-target="#deleteModal" data-message="画像を削除しますか？">
+        画像を削除
+      </button>
+      <%= f.check_box :delete_image, { class: "form-check-input invisible", id: 'delete_image_field', checked: false }, true, false %>
+    </div>
+    <div class="actions">
+      <%= f.submit "更新", class: "submit-button", data: { turbo: false } %>
+    </div>
+    <div class="back-button-container mt-3">
+      <%= link_to 'マイページに戻る', user_path(current_user), class:"back-button", data: { turbo: false } %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -57,6 +57,15 @@
         </div>
       <% end %>
     </div>
+    <div class="mt-4 mb-4">
+      <%= f.label "確認用パスワード", class:"label-tag fw-bold" %><br />
+      <%= f.password_field :password_confirmation, placeholder:"パスワードをもう一度入力してください", class:"text-field p-2", autocomplete: "off" %>
+      <% if @user.errors[:password_confirmation].any? %>
+        <div class="error-message mt-1">
+          <%= raw(@user.errors[:password_confirmation].join("<br>")) %>
+        </div>
+      <% end %>
+    </div>
     <div class="image-field mt-4 mb-5" data-turbo="false">
       <%= f.label "プロフィール画像", class: "label-tag fw-bold" %><br />
       <div class="speech-bubble-area">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,7 @@ ja:
         name: "名前"
         email: "メールアドレス"
         password: "パスワード"
+        password_confirmation: "パスワード(確認)"
         self_introduction: "自己紹介"
         phone_number: 電話番号
       category:
@@ -35,6 +36,9 @@ ja:
               too_long: "255文字以内で入力してください"
             password:
               blank: "パスワードを入力してください。"
+            password_confirmation:
+              confirmation: "%{attribute}と確認用パスワードの入力が一致しません"
+              blank: "パスワードをもう一度入力してください"
             self_introduction:
               too_long: "255文字以内で入力してください"
             phone_number:


### PR DESCRIPTION
## チケットへのリンク
- https://prum.backlog.com/view/PRUM_ACADEMY-2328

## やったこと
- 編集フォームの作成と更新機能の実装
- 確認用パスワードの仮想属性追加（password_confirmation）
- 確認用パスワードをユーザー新規登録、seedにも追加

## やらないこと
- パスワード変更ページ（任意で実施）

## できるようになること（ユーザ目線）
- ユーザー情報を更新できる
- 更新失敗時にエラーメッセージで確認できる
- マイページから編集ページに遷移できる
- マイページに戻れる

## できなくなること（ユーザ目線）
- なし

## デザイン
下記コメント欄に追加

## レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- 今回はパスワードの編集をユーザー編集ページ内で行います。
- 任意でパスワード変更ページを作成し、現在のパスワードと新しいパスワード（確認パスワード含む）を入力して変更します。
- `if: -> { new_record? || changes[:crypted_password] }`によってパスワード以外の項目だけを変更したいとき、パスワードの入力を省略できるようにしています。
- [inputタグの仕様](https://developer.mozilla.org/ja/docs/Web/HTML/Element/input/password)により、データ取得時にパスワードが空で表示される。ユーザーのパスワード登録されてないという誤認識を防止するためにplaceholderの記載を加えています。