### PR TITLE
アカウント削除

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   skip_before_action :require_login, only: [:new, :create]
   before_action :regist_breadcrumb, only: [:new, :create]
   before_action :update_breadcrumb, only: [:edit, :update]
-  before_action :set_user, only: [:show, :edit, :update]
+  before_action :set_user, only: [:show, :edit, :update, :destroy]
 
   def create
     ApplicationRecord.transaction do
@@ -47,6 +47,17 @@ class UsersController < ApplicationController
         flash.now[:alert] = 'ユーザー情報の更新に失敗しました'
         render action: 'edit'
       end
+    end
+  end
+
+  def destroy
+    @user.discard
+    if @user.discarded?
+      flash[:notice] = "退会しました"
+      render json: { status: 'success', user_data: @user }, status: 200
+    else
+      flash.now[:alert] = '退会に失敗しました'
+      render json: { status: 'error', message_type: 'alert', message: "退会に失敗しました" }, status: 400
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,8 @@
 class UsersController < ApplicationController
   skip_before_action :require_login, only: [:new, :create]
   before_action :regist_breadcrumb, only: [:new, :create]
-  before_action :set_user, only: [:show, :edit]
+  before_action :update_breadcrumb, only: [:edit, :update]
+  before_action :set_user, only: [:show, :edit, :update]
 
   def create
     ApplicationRecord.transaction do
@@ -32,10 +33,32 @@ class UsersController < ApplicationController
   def edit
   end
 
+  def update
+    ApplicationRecord.transaction do
+      @user.update(user_params)
+
+      if params[:user][:delete_image] == 'true'
+        @user.image.purge
+      end
+
+      if @user.save
+        redirect_to(user_path(current_user), notice: 'ユーザー情報を更新しました')
+      else
+        flash.now[:alert] = 'ユーザー情報の更新に失敗しました'
+        render action: 'edit'
+      end
+    end
+  end
+
   private
 
   def regist_breadcrumb
     add_breadcrumb 'ユーザー新規登録', new_user_path
+  end
+
+  def update_breadcrumb
+    add_breadcrumb 'マイページ', user_path(current_user)
+    add_breadcrumb 'ユーザー情報編集', edit_user_path
   end
 
   def set_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -66,6 +66,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :phone_number, :self_introduction, :image, :delete_image)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :phone_number, :self_introduction, :image, :delete_image)
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,7 @@
 class Comment < ApplicationRecord
+  include Discard::Model
+  default_scope -> { kept }
+
   belongs_to :user, optional: true
   belongs_to :event
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,10 @@ class User < ApplicationRecord
 
   has_one_attached :image
 
-  has_many :events
-  has_many :comments
+  has_many :events, dependent: :destroy
+  has_many :comments, dependent: :destroy
+
+  after_discard :discard_related_models
 
   validates :name, presence: true, length: { maximum: 100 }
 
@@ -36,6 +38,11 @@ class User < ApplicationRecord
   validates :self_introduction, length: { maximum: 255 }
 
   private
+
+  def discard_related_models
+    events.discard_all if events.present?
+    comments.discard_all if comments.present?
+  end
 
   def validate_password
     if password.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,8 +17,11 @@ class User < ApplicationRecord
   VALID_PASSWORD_MESSAGE_HANKAKU = "パスワードは半角英数字で入力してください"
   VALID_PASSWORD_MESSAGE_MINLENGTH = "パスワードは8文字以上で入力してください"
   VALID_PASSWORD_MESSAGE_MAXLENGTH = "パスワードは16文字以内で入力してください"
-  validates :password, presence: true, if: -> { new_record? || changes[:crypted_password] }
+
+  validates :password, confirmation: true, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validate :validate_password
+
+  validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
   VALID_PHONE_NUMBER_REGEX = /\A\d{10,11}\z/
   VALID_PHONE_NUMBER_MESSAGE_HAIFUN = "電話番号はハイフン無しで入力してください"
@@ -46,5 +49,4 @@ class User < ApplicationRecord
       errors.add(:phone_number, VALID_PHONE_NUMBER_MESSAGE_LENGTH) unless phone_number =~ VALID_PHONE_NUMBER_REGEX
     end
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  include Discard::Model
+  default_scope -> { kept }
+
   has_one_attached :image
 
   has_many :events

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -10,13 +10,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" id="delete-action" class="delete-button btn outline btn-primary" data-bs-dismiss="modal">
-          <span>
-            <% if params[:user].present? && params[:user][:id] == current_user %>
-              退会
-            <% else %>
-              削除
-            <% end %>
-          </span>
+          <span>削除</span>
         </button>
         <button type="button" id="cancel" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
       </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -50,10 +50,19 @@
     </div>
     <div class="mt-4 mb-4">
       <%= f.label "パスワード", class:"label-tag fw-bold" %><br />
-      <%= f.password_field :password, placeholder:"変更時のみパスワードを入力してください", class:"text-field p-2", value: @user.password %>
+      <%= f.password_field :password, placeholder:"変更時のみ新しいパスワードを入力してください", class:"text-field p-2", autocomplete: "off" %>
       <% if @user.errors[:password].any? %>
         <div class="error-message mt-1">
           <%= raw(@user.errors[:password].join("<br>")) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="mt-4 mb-4">
+      <%= f.label "確認用パスワード", class:"label-tag fw-bold" %><br />
+      <%= f.password_field :password_confirmation, placeholder:"新しいパスワードをもう一度入力してください", class:"text-field p-2", autocomplete: "off" %>
+      <% if @user.errors[:password_confirmation].any? %>
+        <div class="error-message mt-1">
+          <%= raw(@user.errors[:password_confirmation].join("<br>")) %>
         </div>
       <% end %>
     </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,84 @@
+<%= render 'shared/modal' %>
+<%= render 'shared/delete_image' %>
+
+<div class="flash-message-container">
+  <%= render 'shared/flash_message' %>
+</div>
+
+<div class="form-breadcrumbs">
+  <%= render_breadcrumbs separator: ' > ' %>
+</div>
+
+<div class="form-container">
+  <h1 class="title">ユーザー情報編集</h1>
+  <%= form_with model: @user, method: :patch do |f| %>
+    <div class="mt-4 mb-4">
+      <%= f.label "名前", class:"label-tag fw-bold" %><br />
+      <%= f.text_field :name, placeholder:"例）山田 太郎", class:"name-field p-2" %>
+      <% if @user.errors[:name].any? %>
+        <div class="error-message mt-1">
+          <%= raw(@user.errors[:name].join("<br>")) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="mt-4 mb-4">
+      <%= f.label "自己紹介", class:"label-tag fw-bold" %><br />
+      <%= f.text_area :self_introduction, placeholder:"自己紹介文を入力", rows: 5, class: "text-area w-100 p-2" %>
+      <% if @user.errors[:self_introduction].any? %>
+        <div class="error-message mt-1">
+          <%= raw(@user.errors[:self_introduction].join("<br>")) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="mt-4 mb-4">
+      <%= f.label "メールアドレス", class:"label-tag fw-bold" %><br />
+      <%= f.text_field :email, placeholder:"例）taro.yamada@example.com", class:"text-field p-2" %>
+      <% if @user.errors[:email].any? %>
+        <div class="error-message mt-1">
+          <%= raw(@user.errors[:email].join("<br>")) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="mt-4 mb-4">
+      <%= f.label "電話番号", class:"label-tag fw-bold" %><br />
+      <%= f.text_field :phone_number, placeholder:"例）0120224568", class:"text-field p-2" %>
+      <% if @user.errors[:phone_number].any? %>
+        <div class="error-message mt-1">
+          <%= raw(@user.errors[:phone_number].join("<br>")) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="mt-4 mb-4">
+      <%= f.label "パスワード", class:"label-tag fw-bold" %><br />
+      <%= f.password_field :password, placeholder:"変更時のみパスワードを入力してください", class:"text-field p-2", value: @user.password %>
+      <% if @user.errors[:password].any? %>
+        <div class="error-message mt-1">
+          <%= raw(@user.errors[:password].join("<br>")) %>
+        </div>
+      <% end %>
+    </div>
+    <div class="image-field mt-4 mb-5" data-turbo="false">
+      <%= f.label "プロフィール画像", class: "label-tag fw-bold" %><br />
+      <div class="speech-bubble-area">
+        <p class="speech-bubble">画像をクリックして、ファイルを選択できます。</p>
+        <% if @user.image.attached? %>
+          <img id="image-preview" src="<%= url_for(@user.image) %>", class="mt-2 mb-2" /><br />
+        <% else %>
+          <img id="image-preview" src="<%= asset_path("default_avatar.png") %>", class="mt-2 mb-2" /><br />
+        <% end %>      </div>
+    </div>
+    <div class="image-button-container">
+      <%= f.file_field :image, class: "upload-button", id: "image-upload" %>
+      <button type="button" id="image-delete-button" class="btn outline btn-primary" data-bs-toggle="modal" data-bs-target="#deleteModal" data-message="画像を削除しますか？">
+        画像を削除
+      </button>
+      <%= f.check_box :delete_image, { class: "form-check-input invisible", id: 'delete_image_field', checked: false }, true, false %>
+    </div>
+    <div class="actions">
+      <%= f.submit "更新", class: "submit-button", data: { turbo: false } %>
+    </div>
+    <div class="back-button-container mt-3">
+      <%= link_to 'マイページに戻る', user_path(current_user), class:"back-button", data: { turbo: false } %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -44,7 +44,7 @@
     <section class="mypage-btns">
       <div class="mypage-actions">
         <%= link_to "編集する", edit_user_path(@user), class: "mypage-submit-button mt-2 mb-2 p-2 fs-6", data: { turbo: false } %>
-        <button type="button" id="user-unsubscribe-button" class="unsubscribe-button btn outline btn-primary" data-bs-toggle="modal" data-bs-target="#deleteModal" data-message="本当に退会しますか？" data-id="<%= current_user.id %>">
+        <button type="button" id="user-unsubscribe-button" class="unsubscribe-button btn outline btn-primary" data-bs-toggle="modal" data-bs-target="#deleteModal" data-message="本当に退会しますか？">
           退会する
         </button>
       </div>
@@ -57,8 +57,9 @@
 document.addEventListener('DOMContentLoaded', () => {
   const unsubscribeButton = document.getElementById('user-unsubscribe-button');
   const accountDelete = document.getElementById('delete-action');
+  const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
 
-  const userId = '<%= current_user.id %>';
+  const userId = <%= current_user.id %>;
 
   //退会モーダルのメッセージ取得
   unsubscribeButton.addEventListener('click', () => {
@@ -71,5 +72,33 @@ document.addEventListener('DOMContentLoaded', () => {
     accountDelete.textContent = "削除";
   }
   });
+
+  //退会ボタンを押して、非同期でDELETEリクエスト送信
+  if (!accountDelete){ return false; }
+  accountDelete.addEventListener("click", async() => {
+    try {
+      if(!userId) { return false; }
+
+      const url = `<%= ENV['DEVELOPMENT_URL'] %>/users/${userId}`;
+
+      const response = await fetch(url, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'X-CSRF-Token': csrfToken
+        },
+      });
+
+      if(response.ok) {
+        window.location.href = `<%= ENV['DEVELOPMENT_URL'] %>/users/new`;
+      } else {
+        const data = await response.json();
+        window.flashMessage(data);
+      }
+    } catch(e) {
+      console.error( e.name, e.message );
+    }
+  })
 });
 </script>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,6 +3,8 @@
     <%= render 'shared/flash_message' %>
   </div>
 
+  <%= render 'shared/modal' %>
+
   <div class="breadcrumbs">
     <%= render_breadcrumbs separator: ' > ' %>
   </div>
@@ -42,7 +44,7 @@
     <section class="mypage-btns">
       <div class="mypage-actions">
         <%= link_to "編集する", edit_user_path(@user), class: "mypage-submit-button mt-2 mb-2 p-2 fs-6", data: { turbo: false } %>
-        <button type="button" id="user-unsubscribe-button" class="unsubscribe-button btn outline btn-primary" data-bs-toggle="modal" data-bs-target="#deleteModal" data-message="本当に退会しますか？">
+        <button type="button" id="user-unsubscribe-button" class="unsubscribe-button btn outline btn-primary" data-bs-toggle="modal" data-bs-target="#deleteModal" data-message="本当に退会しますか？" data-id="<%= current_user.id %>">
           退会する
         </button>
       </div>
@@ -50,3 +52,24 @@
     </section>
   <% end %>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const unsubscribeButton = document.getElementById('user-unsubscribe-button');
+  const accountDelete = document.getElementById('delete-action');
+
+  const userId = '<%= current_user.id %>';
+
+  //退会モーダルのメッセージ取得
+  unsubscribeButton.addEventListener('click', () => {
+  const modalMessage = document.getElementById("modal-message");
+  const dataMessage = unsubscribeButton.getAttribute("data-message");
+  modalMessage.textContent = dataMessage;
+  if(userId) {
+    accountDelete.textContent = "退会";
+  } else {
+    accountDelete.textContent = "削除";
+  }
+  });
+});
+</script>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,7 @@ ja:
         name: "名前"
         email: "メールアドレス"
         password: "パスワード"
+        password_confirmation: "パスワード(確認)"
         self_introduction: "自己紹介"
         phone_number: 電話番号
       category:
@@ -35,6 +36,9 @@ ja:
               too_long: "255文字以内で入力してください"
             password:
               blank: "パスワードを入力してください。"
+            password_confirmation:
+              confirmation: "%{attribute}と確認用パスワードの入力が一致しません"
+              blank: "パスワードをもう一度入力してください"
             self_introduction:
               too_long: "255文字以内で入力してください"
             phone_number:

--- a/db/migrate/20240605205757_add_discarded_at_to_users.rb
+++ b/db/migrate/20240605205757_add_discarded_at_to_users.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :discarded_at, :datetime
+    add_index :users, :discarded_at
+  end
+end

--- a/db/migrate/20240606205113_add_discarded_at_comments.rb
+++ b/db/migrate/20240606205113_add_discarded_at_comments.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtComments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :comments, :discarded_at, :datetime
+    add_index :comments, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_05_205757) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_06_205113) do
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -51,6 +51,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_05_205757) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_comments_on_discarded_at"
     t.index ["event_id"], name: "index_comments_on_event_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_26_043305) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_05_205757) do
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -82,6 +82,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_26_043305) do
     t.string "self_introduction"
     t.datetime "discard_at"
     t.boolean "delete_image", default: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,8 @@
 require 'date'
 
 #ユーザー
-10.times do |n|
-  user = User.create!(name: "test#{n+1}", email: "test#{n+1}@example.com", password: "password#{n+1}", phone_number: "031234000#{n+1}", self_introduction: "テストユーザー#{n+1}です", delete_image: false)
+30.times do |n|
+  user = User.create!(name: "test#{n+1}", email: "test#{n+1}@example.com", password: "password#{n+1}", password_confirmation: "password#{n+1}", phone_number: "031234000#{n+1}", self_introduction: "テストユーザー#{n+1}です", delete_image: false)
   user.image.attach(io: File.open(Rails.root.join('app', 'assets', 'images', 'default_avatar.png')), filename: 'default_avatar.png')
 end
 


### PR DESCRIPTION
## チケットへのリンク
- https://prum.backlog.com/view/PRUM_ACADEMY-2329

## やったこと
- 退会ボタンとモーダルの実装
- 退会機能実装（ユーザー削除）
- 関連するモデル（イベント、コメント）の削除
- 退会後のフラッシュメッセージ表示

## やらないこと
- 退会したユーザーおよび関連モデルのデータ復元（任意）

## できるようになること（ユーザ目線）
- ユーザーが退会できる
- 退会したユーザーのイベントとそれに紐づくコメントも削除できる

## できなくなること（ユーザ目線）
- 退会したユーザーおよび関連するイベントやコメントが復元できない

## デザイン
- 退会するボタン
<img width="1440" alt="スクリーンショット 2024-06-07 7 00 48" src="https://github.com/kyohei-p/event-management-app/assets/107188352/d4d406db-efea-4b01-b217-c0e775806da7">. 

- モーダル
<img width="1440" alt="スクリーンショット 2024-06-07 7 00 52" src="https://github.com/kyohei-p/event-management-app/assets/107188352/0905c3d8-0f1b-4682-9283-85e60d8c82d0">. 

## 動作確認
https://github.com/kyohei-p/event-management-app/assets/107188352/967cf890-65cd-4275-a21b-aa5023061982

## DB
論理削除されたユーザーとイベント（例としてuser_id: 20で検索）
![スクリーンショット 2024-06-07 7 17 21（2）](https://github.com/kyohei-p/event-management-app/assets/107188352/4f4df76f-80d8-49a3-8dc1-6175c645ff1d).

論理削除されたコメント
![スクリーンショット 2024-06-07 7 17 46（2）](https://github.com/kyohei-p/event-management-app/assets/107188352/796cab52-b412-4c0f-939a-cbb36bf41e0c)

## レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- 関連付けられたレコードを削除するために[after_discard](https://github.com/jhawthorn/discard)を追加
- `@user.discard`が呼び出された時にdiscard_related_modelsメソッド内の処理が実行され、関連づけられたモデルのレコードが削除されます。